### PR TITLE
Add tests and improve library quality

### DIFF
--- a/src/Cartesian/Axis.js
+++ b/src/Cartesian/Axis.js
@@ -1,13 +1,13 @@
 import React from "react"
 import PropTypes from "prop-types"
 import * as d3 from 'd3'
-import { dimensionsPropsType } from "../Utils/utils";
 import { useDimensionsContext } from "../Components/Chart";
 
 const axisComponentsByDimension = {
   x: AxisHorizontal,
   y: AxisVertical,
 }
+
 const Axis = ({ dimension, ...props }) => {
   const dimensions = useDimensionsContext()
   const Component = axisComponentsByDimension[dimension]
@@ -23,7 +23,6 @@ const Axis = ({ dimension, ...props }) => {
 
 Axis.propTypes = {
   dimension: PropTypes.oneOf(["x", "y"]),
-  dimensions: dimensionsPropsType,
   scale: PropTypes.func,
   label: PropTypes.string,
   formatTick: PropTypes.func,
@@ -39,6 +38,8 @@ export default Axis
 
 
 function AxisHorizontal ({ dimensions, label, formatTick, scale, ...props }) {
+  if (!scale) return null
+
   const numberOfTicks = dimensions.boundedWidth < 600
         ? dimensions.boundedWidth / 100
         : dimensions.boundedWidth / 250
@@ -54,7 +55,7 @@ function AxisHorizontal ({ dimensions, label, formatTick, scale, ...props }) {
 
       {ticks.map((tick, i) => (
         <text
-          key={tick}
+          key={`${tick}-${i}`}
           className="Axis__tick"
           transform={`translate(${scale(tick)}, 25)`}
         >
@@ -75,6 +76,8 @@ function AxisHorizontal ({ dimensions, label, formatTick, scale, ...props }) {
 }
 
 function AxisVertical ({ dimensions, label, formatTick, scale, ...props }) {
+  if (!scale) return null
+
   const numberOfTicks = dimensions.boundedHeight / 70
 
   const ticks = scale.ticks(numberOfTicks)
@@ -88,7 +91,7 @@ function AxisVertical ({ dimensions, label, formatTick, scale, ...props }) {
 
       {ticks.map((tick, i) => (
         <text
-          key={tick}
+          key={`${tick}-${i}`}
           className="Axis__tick"
           transform={`translate(-16, ${scale(tick)})`}
         >

--- a/src/Charts/Histogram.js
+++ b/src/Charts/Histogram.js
@@ -9,11 +9,14 @@ import Gradient from "../Components/Gradient"
 import { useChartDimensions, accessorPropsType, useUniqueId } from "../Utils/utils";
 
 const gradientColors = ["#9980FA", "rgb(226, 222, 243)"]
-const Histogram = ({ data, xAccessor, label }) => {
+
+const Histogram = ({ data, xAccessor, xLabel, yLabel }) => {
   const gradientId = useUniqueId("Histogram-gradient")
   const [ref, dimensions] = useChartDimensions({
     marginBottom: 77,
   })
+
+  if (!data || data.length === 0) return null
 
   const numberOfThresholds = 9
 
@@ -46,7 +49,7 @@ const Histogram = ({ data, xAccessor, label }) => {
 
   return (
     <div className="Histogram" ref={ref}>
-      <Chart dimensions={dimensions}>
+      <Chart dimensions={dimensions} label={[xLabel, yLabel].filter(Boolean).join(' / ')}>
         <defs>
           <Gradient
             id={gradientId}
@@ -56,16 +59,14 @@ const Histogram = ({ data, xAccessor, label }) => {
           />
         </defs>
         <Axis
-          dimensions={dimensions}
           dimension="x"
           scale={xScale}
-          label={label}
+          label={xLabel}
         />
         <Axis
-          dimensions={dimensions}
           dimension="y"
           scale={yScale}
-          label="Count"
+          label={yLabel || "Count"}
         />
         <Bars
           data={bins}
@@ -82,14 +83,14 @@ const Histogram = ({ data, xAccessor, label }) => {
 }
 
 Histogram.propTypes = {
+  data: PropTypes.array,
   xAccessor: accessorPropsType,
-  yAccessor: accessorPropsType,
   xLabel: PropTypes.string,
   yLabel: PropTypes.string,
 }
 
 Histogram.defaultProps = {
   xAccessor: d => d.x,
-  yAccessor: d => d.y,
 }
+
 export default Histogram

--- a/src/Charts/ScatterPlot.js
+++ b/src/Charts/ScatterPlot.js
@@ -12,13 +12,26 @@ const ScatterPlot = ({ data, xAccessor, yAccessor, xLabel, yLabel }) => {
     marginBottom: 77,
   })
 
+  if (!data || data.length === 0) return null
+
+  const xExtent = d3.extent(data, xAccessor)
+  const yExtent = d3.extent(data, yAccessor)
+
+  // Expand zero-width domains so a single unique value still renders visibly
+  const xDomain = xExtent[0] === xExtent[1]
+    ? [xExtent[0] - 1, xExtent[0] + 1]
+    : xExtent
+  const yDomain = yExtent[0] === yExtent[1]
+    ? [yExtent[0] - 1, yExtent[0] + 1]
+    : yExtent
+
   const xScale = d3.scaleLinear()
-    .domain(d3.extent(data, xAccessor))
+    .domain(xDomain)
     .range([0, dimensions.boundedWidth])
     .nice()
 
   const yScale = d3.scaleLinear()
-    .domain(d3.extent(data, yAccessor))
+    .domain(yDomain)
     .range([dimensions.boundedHeight, 0])
     .nice()
 
@@ -28,15 +41,13 @@ const ScatterPlot = ({ data, xAccessor, yAccessor, xLabel, yLabel }) => {
 
   return (
     <div className="ScatterPlot" ref={ref}>
-      <Chart dimensions={dimensions}>
+      <Chart dimensions={dimensions} label={[xLabel, yLabel].filter(Boolean).join(' / ')}>
         <Axis
-          dimensions={dimensions}
           dimension="x"
           scale={xScale}
           label={xLabel}
         />
         <Axis
-          dimensions={dimensions}
           dimension="y"
           scale={yScale}
           label={yLabel}
@@ -53,6 +64,7 @@ const ScatterPlot = ({ data, xAccessor, yAccessor, xLabel, yLabel }) => {
 }
 
 ScatterPlot.propTypes = {
+  data: PropTypes.array,
   xAccessor: accessorPropsType,
   yAccessor: accessorPropsType,
   xLabel: PropTypes.string,
@@ -63,4 +75,5 @@ ScatterPlot.defaultProps = {
   xAccessor: d => d.x,
   yAccessor: d => d.y,
 }
+
 export default ScatterPlot

--- a/src/Charts/Timeline.js
+++ b/src/Charts/Timeline.js
@@ -11,9 +11,12 @@ import { useChartDimensions, accessorPropsType, useUniqueId } from "../Utils/uti
 const formatDate = d3.timeFormat("%-b %-d")
 const gradientColors = ["rgb(226, 222, 243)", "#f8f9fa"]
 
-const Timeline = ({ data, xAccessor, yAccessor, label }) => {
+const Timeline = ({ data, xAccessor, yAccessor, xLabel, yLabel }) => {
   const [ref, dimensions] = useChartDimensions()
   const gradientId = useUniqueId("Timeline-gradient")
+
+  if (!data || data.length === 0) return null
+
   const xScale = d3.scaleTime()
     .domain(d3.extent(data, xAccessor))
     .range([0, dimensions.boundedWidth])
@@ -29,7 +32,7 @@ const Timeline = ({ data, xAccessor, yAccessor, label }) => {
 
   return (
     <div className="Timeline" ref={ref}>
-      <Chart dimensions={dimensions}>
+      <Chart dimensions={dimensions} label={yLabel || xLabel}>
         <defs>
           <Gradient
             id={gradientId}
@@ -42,11 +45,12 @@ const Timeline = ({ data, xAccessor, yAccessor, label }) => {
           dimension="x"
           scale={xScale}
           formatTick={formatDate}
+          label={xLabel}
         />
         <Axis
           dimension="y"
           scale={yScale}
-          label={label}
+          label={yLabel}
         />
         <Line
           type="area"
@@ -67,13 +71,16 @@ const Timeline = ({ data, xAccessor, yAccessor, label }) => {
 }
 
 Timeline.propTypes = {
-    xAccessor: accessorPropsType,
-    yAccessor: accessorPropsType,
-    label: PropTypes.string,
+  data: PropTypes.array,
+  xAccessor: accessorPropsType,
+  yAccessor: accessorPropsType,
+  xLabel: PropTypes.string,
+  yLabel: PropTypes.string,
 }
 
 Timeline.defaultProps = {
-    xAccessor: d => d.x,
-    yAccessor: d => d.y,
+  xAccessor: d => d.x,
+  yAccessor: d => d.y,
 }
+
 export default Timeline

--- a/src/Components/Chart.js
+++ b/src/Components/Chart.js
@@ -1,4 +1,5 @@
 import React, { createContext, useContext } from "react"
+import PropTypes from "prop-types"
 import { dimensionsPropsType } from "../Utils/utils";
 
 import "./Chart.css"
@@ -6,9 +7,15 @@ import "./Chart.css"
 const ChartContext = createContext()
 export const useDimensionsContext = () => useContext(ChartContext)
 
-const Chart = ({ dimensions, children }) => (
+const Chart = ({ dimensions, children, label }) => (
   <ChartContext.Provider value={dimensions}>
-    <svg className="Chart" width={dimensions.width} height={dimensions.height}>
+    <svg
+      className="Chart"
+      width={dimensions.width}
+      height={dimensions.height}
+      role="img"
+      aria-label={label}
+    >
       <g transform={`translate(${dimensions.marginLeft}, ${dimensions.marginTop})`}>
         { children }
       </g>
@@ -17,7 +24,8 @@ const Chart = ({ dimensions, children }) => (
 )
 
 Chart.propTypes = {
-  dimensions: dimensionsPropsType
+  dimensions: dimensionsPropsType,
+  label: PropTypes.string,
 }
 
 Chart.defaultProps = {

--- a/src/Components/Circles.js
+++ b/src/Components/Circles.js
@@ -10,7 +10,7 @@ const Circles = ({ data, keyAccessor, xAccessor, yAccessor, radius }) => (
         key={keyAccessor(d, i)}
         cx={xAccessor(d, i)}
         cy={yAccessor(d, i)}
-        r={typeof radius == "function" ? radius(d) : radius}
+        r={typeof radius === "function" ? radius(d) : radius}
       />
     ))}
   </React.Fragment>

--- a/src/Components/Gradient.js
+++ b/src/Components/Gradient.js
@@ -5,7 +5,7 @@ const Gradient = ({ id, colors, ...props }) => (
   <linearGradient id={id} gradientUnits="userSpaceOnUse" spreadMethod="pad" {...props}>
     {colors.map((color, i) => (
       <stop
-        key={i}
+        key={`${color}-${i}`}
         offset={`${i * 100 / (colors.length - 1)}%`}
         stopColor={color}
       />

--- a/src/Utils/utils.js
+++ b/src/Utils/utils.js
@@ -1,5 +1,5 @@
-import {PropTypes} from 'prop-types'
-import { useEffect, useState, useRef } from "react"
+import PropTypes from 'prop-types'
+import { useEffect, useState, useRef, useId } from "react"
 import ResizeObserver from "resize-observer-polyfill"
 
 export const accessorPropsType = (
@@ -48,7 +48,7 @@ export const useChartDimensions = passedSettings => {
   const [height, changeHeight] = useState(0)
 
   useEffect(() => {
-    if (dimensions.width && dimensions.height) return [ref, dimensions]
+    if (dimensions.width && dimensions.height) return
 
     const element = ref.current
     const resizeObserver = new ResizeObserver(entries => {
@@ -75,8 +75,8 @@ export const useChartDimensions = passedSettings => {
   return [ref, newSettings]
 }
 
-let lastId = 0
-export const useUniqueId = (prefix="") => {
-  lastId++
-  return [prefix, lastId].join("-")
+// Use React's built-in useId (React 18+) for concurrent-safe unique IDs
+export const useUniqueId = (prefix = "") => {
+  const id = useId().replace(/:/g, '')
+  return `${prefix}-${id}`
 }

--- a/src/__tests__/Chart.test.js
+++ b/src/__tests__/Chart.test.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import Chart, { useDimensionsContext } from '../Components/Chart'
+import Chart from '../Components/Chart'
 
 const dimensions = {
   width: 600,
@@ -25,6 +25,16 @@ describe('Chart', () => {
   it('applies the Chart CSS class to the SVG', () => {
     const { container } = render(<Chart dimensions={dimensions} />)
     expect(container.querySelector('.Chart')).toBeInTheDocument()
+  })
+
+  it('has role="img" for accessibility', () => {
+    const { container } = render(<Chart dimensions={dimensions} />)
+    expect(container.querySelector('svg')).toHaveAttribute('role', 'img')
+  })
+
+  it('sets aria-label when label prop is provided', () => {
+    const { container } = render(<Chart dimensions={dimensions} label="My Chart" />)
+    expect(container.querySelector('svg')).toHaveAttribute('aria-label', 'My Chart')
   })
 
   it('translates the inner <g> by the left and top margins', () => {

--- a/src/__tests__/Histogram.test.js
+++ b/src/__tests__/Histogram.test.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import Histogram from '../Charts/Histogram'
 
-// Spread values across a range wide enough that D3's bin generator produces multiple bins
 const makeData = (n = 30) =>
   Array.from({ length: n }, (_, i) => ({
     humidity: 0.2 + (i / n) * 0.6,
@@ -14,7 +13,7 @@ describe('Histogram', () => {
       <Histogram
         data={makeData()}
         xAccessor={(d) => d.humidity}
-        label="Humidity"
+        xLabel="Humidity"
       />
     )
     expect(container.firstChild).toBeInTheDocument()
@@ -25,7 +24,7 @@ describe('Histogram', () => {
       <Histogram
         data={makeData()}
         xAccessor={(d) => d.humidity}
-        label="Humidity"
+        xLabel="Humidity"
       />
     )
     expect(container.querySelector('.Histogram')).toBeInTheDocument()
@@ -48,7 +47,6 @@ describe('Histogram', () => {
         xAccessor={(d) => d.humidity}
       />
     )
-    // D3 histogram with 9 thresholds over [0.2, 0.8] produces ~9 bins
     expect(container.querySelectorAll('.Bars__rect').length).toBeGreaterThan(0)
   })
 
@@ -62,10 +60,17 @@ describe('Histogram', () => {
     expect(container.querySelector('defs')).toBeInTheDocument()
   })
 
+  it('renders nothing for empty data', () => {
+    const { container } = render(
+      <Histogram data={[]} xAccessor={(d) => d.humidity} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
   it('uses the default x-accessor when none is supplied', () => {
     const defaultData = makeData().map((d) => ({ x: d.humidity }))
     expect(() =>
-      render(<Histogram data={defaultData} label="X" />)
+      render(<Histogram data={defaultData} xLabel="X" />)
     ).not.toThrow()
   })
 })

--- a/src/__tests__/ScatterPlot.test.js
+++ b/src/__tests__/ScatterPlot.test.js
@@ -57,6 +57,26 @@ describe('ScatterPlot', () => {
     expect(container.querySelectorAll('circle')).toHaveLength(5)
   })
 
+  it('renders nothing for empty data', () => {
+    const { container } = render(
+      <ScatterPlot data={[]} xAccessor={(d) => d.humidity} yAccessor={(d) => d.temperature} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('handles data where all x values are identical', () => {
+    const data = Array.from({ length: 5 }, () => ({ humidity: 0.5, temperature: 70 }))
+    expect(() =>
+      render(
+        <ScatterPlot
+          data={data}
+          xAccessor={(d) => d.humidity}
+          yAccessor={(d) => d.temperature}
+        />
+      )
+    ).not.toThrow()
+  })
+
   it('uses default accessors when none are supplied', () => {
     const defaultData = makeData().map((d, i) => ({ x: d.humidity, y: d.temperature }))
     expect(() =>

--- a/src/__tests__/Timeline.test.js
+++ b/src/__tests__/Timeline.test.js
@@ -15,7 +15,7 @@ describe('Timeline', () => {
         data={makeData()}
         xAccessor={(d) => d.date}
         yAccessor={(d) => d.temperature}
-        label="Temperature"
+        yLabel="Temperature"
       />
     )
     expect(container.firstChild).toBeInTheDocument()
@@ -66,10 +66,17 @@ describe('Timeline', () => {
     expect(container.querySelector('defs')).toBeInTheDocument()
   })
 
+  it('renders nothing for empty data', () => {
+    const { container } = render(
+      <Timeline data={[]} xAccessor={(d) => d.date} yAccessor={(d) => d.temperature} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
   it('uses default accessors when none are supplied', () => {
     const defaultData = makeData().map((d, i) => ({ x: i, y: d.temperature }))
     expect(() =>
-      render(<Timeline data={defaultData} label="Test" />)
+      render(<Timeline data={defaultData} yLabel="Test" />)
     ).not.toThrow()
   })
 })

--- a/src/__tests__/utils.test.js
+++ b/src/__tests__/utils.test.js
@@ -54,7 +54,7 @@ describe('callAccessor', () => {
 describe('useUniqueId', () => {
   it('returns a string containing the prefix', () => {
     const { result } = renderHook(() => useUniqueId('myprefix'))
-    expect(result.current).toMatch(/^myprefix-\d+$/)
+    expect(result.current).toMatch(/^myprefix-.+$/)
   })
 
   it('generates unique IDs across separate calls', () => {
@@ -63,8 +63,9 @@ describe('useUniqueId', () => {
     expect(r1.current).not.toBe(r2.current)
   })
 
-  it('uses an empty string prefix when none is provided', () => {
+  it('still produces a string when no prefix is provided', () => {
     const { result } = renderHook(() => useUniqueId())
-    expect(result.current).toMatch(/^-\d+$/)
+    expect(typeof result.current).toBe('string')
+    expect(result.current.length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
## Summary

- **Test suite** — adds Jest + React Testing Library with 48 tests across all components and charts
- **Bug fixes** — broken `PropTypes` import, dead `useEffect` return value, null `scale` crash in `Axis`
- **API consistency** — `Timeline`/`Histogram` now use `xLabel`/`yLabel` to match `ScatterPlot`
- **Edge cases** — all charts return `null` on empty data; `ScatterPlot` handles single-value domains
- **Code quality** — `useUniqueId` replaced with React 18's `useId`, strict equality in `Circles`, `role="img"` + `aria-label` on `Chart` SVG, stable keys in `Gradient`
- **CI** — updated Node.js matrix from EOL 12/14/16 to 18/20/22; added `.npmrc` for consistent peer dep resolution

## Test plan

- [ ] `npm test` passes (48 tests)
- [ ] `npm run build-lib` succeeds
- [ ] CI checks pass on Node 18, 20, 22
- [ ] Verify `Timeline` uses `yLabel`, `Histogram` uses `xLabel`/`yLabel`
- [ ] Verify charts render `null` when passed an empty array