### PR TITLE
Add BarChart for categorical data comparison

### DIFF
--- a/src/Cartesian/Axis.js
+++ b/src/Cartesian/Axis.js
@@ -44,7 +44,13 @@ function AxisHorizontal ({ dimensions, label, formatTick, scale, ...props }) {
         ? dimensions.boundedWidth / 100
         : dimensions.boundedWidth / 250
 
-  const ticks = scale.ticks(numberOfTicks)
+  // scaleBand (categorical) has no .ticks() — use .domain() instead
+  const ticks = typeof scale.ticks === 'function'
+    ? scale.ticks(numberOfTicks)
+    : scale.domain()
+
+  // Center labels within each band for band/ordinal scales
+  const tickOffset = typeof scale.bandwidth === 'function' ? scale.bandwidth() / 2 : 0
 
   return (
     <g className="Axis AxisHorizontal" transform={`translate(0, ${dimensions.boundedHeight})`} {...props}>
@@ -57,7 +63,7 @@ function AxisHorizontal ({ dimensions, label, formatTick, scale, ...props }) {
         <text
           key={`${tick}-${i}`}
           className="Axis__tick"
-          transform={`translate(${scale(tick)}, 25)`}
+          transform={`translate(${scale(tick) + tickOffset}, 25)`}
         >
           { formatTick(tick) }
         </text>

--- a/src/Charts/BarChart.js
+++ b/src/Charts/BarChart.js
@@ -1,0 +1,73 @@
+import React from "react"
+import PropTypes from "prop-types"
+import * as d3 from "d3"
+
+import Chart from "../Components/Chart"
+import Bars from "../Components/Bars"
+import Axis from "../Cartesian/Axis"
+import { useChartDimensions, accessorPropsType } from "../Utils/utils"
+
+const BarChart = ({ data, xAccessor, yAccessor, xLabel, yLabel }) => {
+  const [ref, dimensions] = useChartDimensions({
+    marginBottom: 77,
+  })
+
+  if (!data || data.length === 0) return null
+
+  const xScale = d3.scaleBand()
+    .domain(data.map(xAccessor))
+    .range([0, dimensions.boundedWidth])
+    .padding(0.2)
+
+  const yScale = d3.scaleLinear()
+    .domain([0, d3.max(data, yAccessor)])
+    .range([dimensions.boundedHeight, 0])
+    .nice()
+
+  const xAccessorScaled = d => xScale(xAccessor(d))
+  const yAccessorScaled = d => yScale(yAccessor(d))
+  const widthAccessorScaled = () => xScale.bandwidth()
+  const heightAccessorScaled = d => dimensions.boundedHeight - yScale(yAccessor(d))
+  const keyAccessor = (d, i) => i
+
+  return (
+    <div className="BarChart" ref={ref}>
+      <Chart dimensions={dimensions} label={[xLabel, yLabel].filter(Boolean).join(' / ')}>
+        <Axis
+          dimension="x"
+          scale={xScale}
+          formatTick={d => d}
+          label={xLabel}
+        />
+        <Axis
+          dimension="y"
+          scale={yScale}
+          label={yLabel}
+        />
+        <Bars
+          data={data}
+          keyAccessor={keyAccessor}
+          xAccessor={xAccessorScaled}
+          yAccessor={yAccessorScaled}
+          widthAccessor={widthAccessorScaled}
+          heightAccessor={heightAccessorScaled}
+        />
+      </Chart>
+    </div>
+  )
+}
+
+BarChart.propTypes = {
+  data: PropTypes.array,
+  xAccessor: accessorPropsType,
+  yAccessor: accessorPropsType,
+  xLabel: PropTypes.string,
+  yLabel: PropTypes.string,
+}
+
+BarChart.defaultProps = {
+  xAccessor: d => d.x,
+  yAccessor: d => d.y,
+}
+
+export default BarChart

--- a/src/Charts/index.js
+++ b/src/Charts/index.js
@@ -1,3 +1,4 @@
+export {default as BarChart} from './BarChart';
 export {default as Histogram} from './Histogram';
 export {default as ScatterPlot} from './ScatterPlot';
 export {default as Timeline} from './Timeline';

--- a/src/__tests__/BarChart.test.js
+++ b/src/__tests__/BarChart.test.js
@@ -1,0 +1,86 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import BarChart from '../Charts/BarChart'
+
+const makeData = () => [
+  { category: 'Mon', value: 12 },
+  { category: 'Tue', value: 8 },
+  { category: 'Wed', value: 15 },
+  { category: 'Thu', value: 6 },
+  { category: 'Fri', value: 20 },
+]
+
+describe('BarChart', () => {
+  it('renders without crashing', () => {
+    const { container } = render(
+      <BarChart
+        data={makeData()}
+        xAccessor={d => d.category}
+        yAccessor={d => d.value}
+        xLabel="Day"
+        yLabel="Sales"
+      />
+    )
+    expect(container.firstChild).toBeInTheDocument()
+  })
+
+  it('wraps content in a div with class "BarChart"', () => {
+    const { container } = render(
+      <BarChart
+        data={makeData()}
+        xAccessor={d => d.category}
+        yAccessor={d => d.value}
+      />
+    )
+    expect(container.querySelector('.BarChart')).toBeInTheDocument()
+  })
+
+  it('renders an SVG chart', () => {
+    const { container } = render(
+      <BarChart
+        data={makeData()}
+        xAccessor={d => d.category}
+        yAccessor={d => d.value}
+      />
+    )
+    expect(container.querySelector('svg.Chart')).toBeInTheDocument()
+  })
+
+  it('renders one rect per data point', () => {
+    const data = makeData()
+    const { container } = render(
+      <BarChart
+        data={data}
+        xAccessor={d => d.category}
+        yAccessor={d => d.value}
+      />
+    )
+    expect(container.querySelectorAll('.Bars__rect')).toHaveLength(data.length)
+  })
+
+  it('renders nothing for empty data', () => {
+    const { container } = render(
+      <BarChart data={[]} xAccessor={d => d.category} yAccessor={d => d.value} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('uses default accessors when none are supplied', () => {
+    const defaultData = makeData().map(d => ({ x: d.category, y: d.value }))
+    expect(() =>
+      render(<BarChart data={defaultData} />)
+    ).not.toThrow()
+  })
+
+  it('renders x and y axis elements', () => {
+    const { container } = render(
+      <BarChart
+        data={makeData()}
+        xAccessor={d => d.category}
+        yAccessor={d => d.value}
+      />
+    )
+    expect(container.querySelector('.AxisHorizontal')).toBeInTheDocument()
+    expect(container.querySelector('.AxisVertical')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- **New `BarChart` component** — compares categorical values side by side using `d3.scaleBand` for the x-axis and `d3.scaleLinear` for the y-axis
- **`Axis` improvement** — `AxisHorizontal` now supports band/ordinal scales (falls back to `scale.domain()` when `scale.ticks()` is unavailable, centers labels with `scale.bandwidth() / 2`)
- Reuses existing `Bars` and `Axis` primitives — no new SVG primitives needed
- Consistent API with the rest of the library (`xLabel`/`yLabel`, empty data returns `null`, default accessors)

```jsx
<BarChart
  data={[{ category: 'Mon', value: 12 }, { category: 'Tue', value: 8 }]}
  xAccessor={d => d.category}
  yAccessor={d => d.value}
  xLabel="Day"
  yLabel="Sales"
/>
```

## Test plan

- [ ] `npm test` passes (55 tests, 7 new for `BarChart`)
- [ ] `npm run build-lib` succeeds
- [ ] CI checks pass on Node 18, 20, 22
- [ ] Verify bars render one rect per data point
- [ ] Verify x-axis tick labels are centered within each bar
- [ ] Verify empty data renders nothing

https://claude.ai/code/session_01Bf9veNX9mqfMqrCEGnujAo