### PR TITLE
Add interactive tooltips and hover highlights to all charts

### DIFF
--- a/src/Charts/BarChart.js
+++ b/src/Charts/BarChart.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useRef, useState } from "react"
 import PropTypes from "prop-types"
 import * as d3 from "d3"
 
@@ -6,9 +6,11 @@ import Chart from "../Components/Chart"
 import Bars from "../Components/Bars"
 import Axis from "../Cartesian/Axis"
 import Legend from "../Components/Legend"
+import Tooltip from "../Components/Tooltip"
 import { useChartDimensions, accessorPropsType } from "../Utils/utils"
 
 const DEFAULT_COLOR = '#9980FA'
+const fmt = d3.format(",")
 
 const BarChart = ({
   data, xAccessor, yAccessor, xLabel, yLabel,
@@ -16,6 +18,8 @@ const BarChart = ({
   showLegend, legendPosition,
 }) => {
   const [ref, dimensions] = useChartDimensions({ marginBottom: 77 })
+  const wrapperRef = useRef()
+  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0, d: null })
 
   if (!data || data.length === 0) return null
 
@@ -34,6 +38,21 @@ const BarChart = ({
   const widthAccessorScaled = () => xScale.bandwidth()
   const heightAccessorScaled = d => dimensions.boundedHeight - yScale(yAccessor(d))
   const keyAccessor = (d, i) => i
+
+  const getPos = e => {
+    const { left, top } = wrapperRef.current.getBoundingClientRect()
+    return { x: e.clientX - left, y: e.clientY - top }
+  }
+
+  const handleEnter = (d, i, e) => {
+    const { x, y } = getPos(e)
+    setTooltip({ visible: true, x, y, d })
+  }
+  const handleMove = (d, i, e) => {
+    const { x, y } = getPos(e)
+    setTooltip(t => ({ ...t, x, y }))
+  }
+  const handleLeave = () => setTooltip(t => ({ ...t, visible: false }))
 
   const legendItems = yLabel
     ? [{ color: color || DEFAULT_COLOR, label: yLabel }]
@@ -55,6 +74,9 @@ const BarChart = ({
           widthAccessor={widthAccessorScaled}
           heightAccessor={heightAccessorScaled}
           style={color ? { fill: color } : undefined}
+          onMouseEnter={handleEnter}
+          onMouseMove={handleMove}
+          onMouseLeave={handleLeave}
         />
       </Chart>
     </div>
@@ -65,10 +87,18 @@ const BarChart = ({
     : null
 
   return (
-    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column' }}>
+    <div ref={wrapperRef} style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column', position: 'relative' }}>
       {isLeading && legend}
       {chart}
       {!isLeading && legend}
+      <Tooltip visible={tooltip.visible} x={tooltip.x} y={tooltip.y}>
+        {tooltip.d && (
+          <>
+            <div><strong>{xLabel || 'Category'}</strong>: {xAccessor(tooltip.d)}</div>
+            <div><strong>{yLabel || 'Value'}</strong>: {fmt(yAccessor(tooltip.d))}</div>
+          </>
+        )}
+      </Tooltip>
     </div>
   )
 }

--- a/src/Charts/Histogram.js
+++ b/src/Charts/Histogram.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useRef, useState } from "react"
 import PropTypes from "prop-types"
 import * as d3 from "d3"
 
@@ -7,10 +7,13 @@ import Bars from "../Components/Bars"
 import Axis from "../Cartesian/Axis"
 import Gradient from "../Components/Gradient"
 import Legend from "../Components/Legend"
+import Tooltip from "../Components/Tooltip"
 import { useChartDimensions, accessorPropsType, useUniqueId } from "../Utils/utils"
 
 const defaultGradientColors = ["#9980FA", "rgb(226, 222, 243)"]
 const DEFAULT_COLOR = '#9980FA'
+const fmt = d3.format(",")
+const fmtFixed = d3.format(",.2~f")
 
 const Histogram = ({
   data, xAccessor, xLabel, yLabel,
@@ -20,6 +23,8 @@ const Histogram = ({
 }) => {
   const gradientId = useUniqueId("Histogram-gradient")
   const [ref, dimensions] = useChartDimensions({ marginBottom: 77 })
+  const wrapperRef = useRef()
+  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0, d: null })
 
   if (!data || data.length === 0) return null
 
@@ -52,6 +57,23 @@ const Histogram = ({
   const resolvedGradientColors = gradientColorsProp || defaultGradientColors
   const barStyle = color ? { fill: color } : { fill: `url(#${gradientId})` }
 
+  const tickFmt = formatXTick || fmtFixed
+
+  const getPos = e => {
+    const { left, top } = wrapperRef.current.getBoundingClientRect()
+    return { x: e.clientX - left, y: e.clientY - top }
+  }
+
+  const handleEnter = (d, i, e) => {
+    const { x, y } = getPos(e)
+    setTooltip({ visible: true, x, y, d })
+  }
+  const handleMove = (d, i, e) => {
+    const { x, y } = getPos(e)
+    setTooltip(t => ({ ...t, x, y }))
+  }
+  const handleLeave = () => setTooltip(t => ({ ...t, visible: false }))
+
   const legendItems = xLabel
     ? [{ color: color || DEFAULT_COLOR, label: xLabel }]
     : []
@@ -75,6 +97,9 @@ const Histogram = ({
           widthAccessor={widthAccessorScaled}
           heightAccessor={heightAccessorScaled}
           style={barStyle}
+          onMouseEnter={handleEnter}
+          onMouseMove={handleMove}
+          onMouseLeave={handleLeave}
         />
       </Chart>
     </div>
@@ -85,10 +110,18 @@ const Histogram = ({
     : null
 
   return (
-    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column' }}>
+    <div ref={wrapperRef} style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column', position: 'relative' }}>
       {isLeading && legend}
       {chart}
       {!isLeading && legend}
+      <Tooltip visible={tooltip.visible} x={tooltip.x} y={tooltip.y}>
+        {tooltip.d && (
+          <>
+            <div><strong>{xLabel || 'Range'}</strong>: {tickFmt(tooltip.d.x0)} – {tickFmt(tooltip.d.x1)}</div>
+            <div><strong>Count</strong>: {fmt(tooltip.d.length)}</div>
+          </>
+        )}
+      </Tooltip>
     </div>
   )
 }

--- a/src/Charts/PieChart.js
+++ b/src/Charts/PieChart.js
@@ -1,13 +1,15 @@
-import React from "react"
+import React, { useRef, useState } from "react"
 import PropTypes from "prop-types"
 import * as d3 from "d3"
 
 import Chart from "../Components/Chart"
 import Legend from "../Components/Legend"
+import Tooltip from "../Components/Tooltip"
 import { useChartDimensions, accessorPropsType } from "../Utils/utils"
 
 const defaultMargin = { marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20 }
 const MIN_LABEL_ANGLE = 0.35
+const fmt = d3.format(",")
 
 const PieChart = ({
   data, valueAccessor, labelAccessor,
@@ -15,6 +17,8 @@ const PieChart = ({
   showLegend, legendPosition,
 }) => {
   const [ref, dimensions] = useChartDimensions(defaultMargin)
+  const wrapperRef = useRef()
+  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0, datum: null, label: null })
 
   if (!data || data.length === 0) return null
 
@@ -50,6 +54,8 @@ const PieChart = ({
   const arcs = pieGenerator(data)
   const displayLabels = showLabels !== false && typeof labelAccessor === 'function'
 
+  const total = d3.sum(data, valueAccessor)
+
   const legendItems = typeof labelAccessor === 'function'
     ? data.map((d, i) => {
         const label = labelAccessor(d)
@@ -60,6 +66,21 @@ const PieChart = ({
   const resolvedPosition = legendPosition || 'bottom'
   const isHorizontal = resolvedPosition === 'left' || resolvedPosition === 'right'
   const isLeading = resolvedPosition === 'top' || resolvedPosition === 'left'
+
+  const getPos = e => {
+    const { left, top } = wrapperRef.current.getBoundingClientRect()
+    return { x: e.clientX - left, y: e.clientY - top }
+  }
+
+  const handleSliceEnter = (datum, label, e) => {
+    const { x, y } = getPos(e)
+    setTooltip({ visible: true, x, y, datum, label })
+  }
+  const handleSliceMove = (datum, label, e) => {
+    const { x, y } = getPos(e)
+    setTooltip(t => ({ ...t, x, y }))
+  }
+  const handleSliceLeave = () => setTooltip(t => ({ ...t, visible: false }))
 
   const chart = (
     <div className="PieChart" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
@@ -74,12 +95,15 @@ const PieChart = ({
                   className="PieChart__slice"
                   d={arcGenerator(arc)}
                   style={{ fill: colorScale(label) }}
+                  onMouseEnter={e => handleSliceEnter(data[i], label, e)}
+                  onMouseMove={e => handleSliceMove(data[i], label, e)}
+                  onMouseLeave={handleSliceLeave}
                 />
                 {displayLabels && sliceAngle >= MIN_LABEL_ANGLE && (
                   <text
                     className="PieChart__label"
                     transform={`translate(${labelArc.centroid(arc)})`}
-                    style={{ textAnchor: 'middle', dominantBaseline: 'middle' }}
+                    style={{ textAnchor: 'middle', dominantBaseline: 'middle', pointerEvents: 'none' }}
                   >
                     {label}
                   </text>
@@ -96,11 +120,22 @@ const PieChart = ({
     ? <Legend items={legendItems} position={resolvedPosition} />
     : null
 
+  const tooltipValue = tooltip.datum ? valueAccessor(tooltip.datum) : 0
+  const tooltipPct = total > 0 ? Math.round(tooltipValue / total * 100) : 0
+
   return (
-    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column' }}>
+    <div ref={wrapperRef} style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column', position: 'relative' }}>
       {isLeading && legend}
       {chart}
       {!isLeading && legend}
+      <Tooltip visible={tooltip.visible} x={tooltip.x} y={tooltip.y}>
+        {tooltip.datum && (
+          <>
+            <div><strong>{tooltip.label}</strong></div>
+            <div>{fmt(tooltipValue)} ({tooltipPct}%)</div>
+          </>
+        )}
+      </Tooltip>
     </div>
   )
 }

--- a/src/Charts/ScatterPlot.js
+++ b/src/Charts/ScatterPlot.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useRef, useState } from "react"
 import PropTypes from "prop-types"
 import * as d3 from "d3"
 
@@ -6,9 +6,11 @@ import Chart from "../Components/Chart"
 import Circles from "../Components/Circles"
 import Axis from "../Cartesian/Axis"
 import Legend from "../Components/Legend"
+import Tooltip from "../Components/Tooltip"
 import { useChartDimensions, accessorPropsType } from "../Utils/utils"
 
 const DEFAULT_COLOR = '#9980FA'
+const fmt = d3.format(",")
 
 const ScatterPlot = ({
   data, xAccessor, yAccessor, xLabel, yLabel,
@@ -16,6 +18,8 @@ const ScatterPlot = ({
   showLegend, legendPosition,
 }) => {
   const [ref, dimensions] = useChartDimensions({ marginBottom: 77 })
+  const wrapperRef = useRef()
+  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0, d: null })
 
   if (!data || data.length === 0) return null
 
@@ -36,6 +40,21 @@ const ScatterPlot = ({
   const yAccessorScaled = d => yScale(yAccessor(d))
   const keyAccessor = (d, i) => i
 
+  const getPos = e => {
+    const { left, top } = wrapperRef.current.getBoundingClientRect()
+    return { x: e.clientX - left, y: e.clientY - top }
+  }
+
+  const handleEnter = (d, i, e) => {
+    const { x, y } = getPos(e)
+    setTooltip({ visible: true, x, y, d })
+  }
+  const handleMove = (d, i, e) => {
+    const { x, y } = getPos(e)
+    setTooltip(t => ({ ...t, x, y }))
+  }
+  const handleLeave = () => setTooltip(t => ({ ...t, visible: false }))
+
   const legendItems = yLabel
     ? [{ color: color || DEFAULT_COLOR, label: yLabel }]
     : []
@@ -55,6 +74,9 @@ const ScatterPlot = ({
           yAccessor={yAccessorScaled}
           radius={radius}
           color={color}
+          onMouseEnter={handleEnter}
+          onMouseMove={handleMove}
+          onMouseLeave={handleLeave}
         />
       </Chart>
     </div>
@@ -65,10 +87,18 @@ const ScatterPlot = ({
     : null
 
   return (
-    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column' }}>
+    <div ref={wrapperRef} style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column', position: 'relative' }}>
       {isLeading && legend}
       {chart}
       {!isLeading && legend}
+      <Tooltip visible={tooltip.visible} x={tooltip.x} y={tooltip.y}>
+        {tooltip.d && (
+          <>
+            <div><strong>{xLabel || 'X'}</strong>: {fmt(xAccessor(tooltip.d))}</div>
+            <div><strong>{yLabel || 'Y'}</strong>: {fmt(yAccessor(tooltip.d))}</div>
+          </>
+        )}
+      </Tooltip>
     </div>
   )
 }

--- a/src/Charts/Timeline.js
+++ b/src/Charts/Timeline.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useRef, useState } from "react"
 import PropTypes from "prop-types"
 import * as d3 from "d3"
 
@@ -8,11 +8,14 @@ import Circles from "../Components/Circles"
 import Axis from "../Cartesian/Axis"
 import Gradient from "../Components/Gradient"
 import Legend from "../Components/Legend"
+import Tooltip from "../Components/Tooltip"
 import { useChartDimensions, accessorPropsType, useUniqueId } from "../Utils/utils"
 
 const formatDate = d3.timeFormat("%-b %-d")
+const formatTooltipDate = d3.timeFormat("%-b %-d, %Y")
 const defaultGradientColors = ["rgb(226, 222, 243)", "#f8f9fa"]
 const DEFAULT_COLOR = '#9980FA'
+const fmt = d3.format(",")
 
 const Timeline = ({
   data, xAccessor, yAccessor, xLabel, yLabel,
@@ -23,6 +26,9 @@ const Timeline = ({
 }) => {
   const [ref, dimensions] = useChartDimensions({ marginBottom: 77 })
   const gradientId = useUniqueId("Timeline-gradient")
+  const wrapperRef = useRef()
+  const [hovered, setHovered] = useState(null)
+  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0 })
 
   if (!data || data.length === 0) return null
 
@@ -41,6 +47,35 @@ const Timeline = ({
   const xAccessorScaled = d => xScale(xAccessor(d))
   const yAccessorScaled = d => yScale(yAccessor(d))
   const y0AccessorScaled = yScale(yScale.domain()[0])
+
+  const bisect = d3.bisector(xAccessor).left
+
+  const handleMouseMove = e => {
+    const svgEl = e.currentTarget.ownerSVGElement
+    const svgBounds = svgEl.getBoundingClientRect()
+    const mouseX = e.clientX - svgBounds.left - dimensions.marginLeft
+
+    const date = xScale.invert(mouseX)
+    const idx = bisect(data, date, 1)
+    const d0 = data[idx - 1]
+    const d1 = data[idx]
+    const hoveredDatum = !d1 || (d0 && date - xAccessor(d0) < xAccessor(d1) - date)
+      ? idx - 1 : idx
+
+    setHovered(hoveredDatum)
+
+    const { left, top } = wrapperRef.current.getBoundingClientRect()
+    setTooltip({ visible: true, x: e.clientX - left, y: e.clientY - top })
+  }
+
+  const handleMouseLeave = () => {
+    setHovered(null)
+    setTooltip(t => ({ ...t, visible: false }))
+  }
+
+  const hoveredDatum = hovered !== null ? data[hovered] : null
+  const yFmt = formatYTick || fmt
+  const xFmt = formatXTick || formatTooltipDate
 
   const legendItems = yLabel
     ? [{ color: color || DEFAULT_COLOR, label: yLabel }]
@@ -84,6 +119,34 @@ const Timeline = ({
             color={color}
           />
         )}
+        {hoveredDatum && (
+          <>
+            <line
+              className="Timeline__hover-line"
+              x1={xAccessorScaled(hoveredDatum)}
+              x2={xAccessorScaled(hoveredDatum)}
+              y1={0}
+              y2={dimensions.boundedHeight}
+            />
+            <circle
+              className="Timeline__hover-dot"
+              cx={xAccessorScaled(hoveredDatum)}
+              cy={yAccessorScaled(hoveredDatum)}
+              r={5}
+              style={{ stroke: color || DEFAULT_COLOR }}
+            />
+          </>
+        )}
+        <rect
+          x={0}
+          y={0}
+          width={dimensions.boundedWidth}
+          height={dimensions.boundedHeight}
+          fill="none"
+          style={{ pointerEvents: 'all' }}
+          onMouseMove={handleMouseMove}
+          onMouseLeave={handleMouseLeave}
+        />
       </Chart>
     </div>
   )
@@ -93,10 +156,18 @@ const Timeline = ({
     : null
 
   return (
-    <div style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column' }}>
+    <div ref={wrapperRef} style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column', position: 'relative' }}>
       {isLeading && legend}
       {chart}
       {!isLeading && legend}
+      <Tooltip visible={tooltip.visible} x={tooltip.x} y={tooltip.y}>
+        {hoveredDatum && (
+          <>
+            <div><strong>{xFmt(xAccessor(hoveredDatum))}</strong></div>
+            <div>{yLabel || 'Value'}: {yFmt(yAccessor(hoveredDatum))}</div>
+          </>
+        )}
+      </Tooltip>
     </div>
   )
 }
@@ -114,9 +185,7 @@ Timeline.propTypes = {
   showDots: PropTypes.bool,
   formatXTick: PropTypes.func,
   formatYTick: PropTypes.func,
-  /** Show a legend for the chart. Default: false. */
   showLegend: PropTypes.bool,
-  /** Position of the legend. One of 'top', 'bottom', 'left', 'right'. Default: 'bottom'. */
   legendPosition: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
 }
 

--- a/src/Components/Bars.js
+++ b/src/Components/Bars.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types"
 import * as d3 from 'd3'
 import { accessorPropsType, callAccessor } from "../Utils/utils";
 
-const Bars = ({ data, keyAccessor, xAccessor, yAccessor, widthAccessor, heightAccessor, ...props }) => (
+const Bars = ({ data, keyAccessor, xAccessor, yAccessor, widthAccessor, heightAccessor, onMouseEnter, onMouseLeave, onMouseMove, ...props }) => (
   <React.Fragment>
     {data.map((d, i) => (
       <rect {...props}
@@ -13,6 +13,9 @@ const Bars = ({ data, keyAccessor, xAccessor, yAccessor, widthAccessor, heightAc
         y={callAccessor(yAccessor, d, i)}
         width={d3.max([callAccessor(widthAccessor, d, i), 0])}
         height={d3.max([callAccessor(heightAccessor, d, i), 0])}
+        onMouseEnter={onMouseEnter ? e => onMouseEnter(d, i, e) : undefined}
+        onMouseLeave={onMouseLeave ? e => onMouseLeave(d, i, e) : undefined}
+        onMouseMove={onMouseMove ? e => onMouseMove(d, i, e) : undefined}
       />
     ))}
   </React.Fragment>

--- a/src/Components/Chart.css
+++ b/src/Components/Chart.css
@@ -48,12 +48,47 @@
 
 .Circles__circle {
     fill: #9980FA;
-    transition: all 0.3s ease-out;
+    transition: opacity 0.15s ease-out, r 0.15s ease-out;
+    cursor: pointer;
 }
 
 .Bars__rect {
     fill: #9980FA;
-    transition: all 0.3s ease-out;
+    transition: opacity 0.15s ease-out;
+    cursor: pointer;
+}
+
+.PieChart__slice {
+    transition: opacity 0.15s ease-out;
+    cursor: pointer;
+}
+
+/* Dim siblings of the hovered element */
+.BarChart:has(.Bars__rect:hover) .Bars__rect:not(:hover),
+.Histogram:has(.Bars__rect:hover) .Bars__rect:not(:hover) {
+    opacity: 0.35;
+}
+
+.ScatterPlot:has(.Circles__circle:hover) .Circles__circle:not(:hover) {
+    opacity: 0.35;
+}
+
+.PieChart:has(.PieChart__slice:hover) .PieChart__slice:not(:hover) {
+    opacity: 0.35;
+}
+
+/* Timeline hover elements */
+.Timeline__hover-line {
+    stroke: #aaa;
+    stroke-width: 1px;
+    stroke-dasharray: 4 3;
+    pointer-events: none;
+}
+
+.Timeline__hover-dot {
+    fill: #fff;
+    stroke-width: 2.5px;
+    pointer-events: none;
 }
 
 .domain,

--- a/src/Components/Circles.js
+++ b/src/Components/Circles.js
@@ -2,16 +2,19 @@ import React from "react"
 import PropTypes from "prop-types"
 import { accessorPropsType } from "../Utils/utils";
 
-const Circles = ({ data, keyAccessor, xAccessor, yAccessor, radius, color }) => (
+const Circles = ({ data, keyAccessor, xAccessor, yAccessor, radius, color, onMouseEnter, onMouseLeave, onMouseMove, ...props }) => (
   <React.Fragment>
     {data.map((d, i) => (
-      <circle
+      <circle {...props}
         className="Circles__circle"
         key={keyAccessor(d, i)}
         cx={xAccessor(d, i)}
         cy={yAccessor(d, i)}
         r={typeof radius === "function" ? radius(d) : radius}
         style={color ? { fill: color } : undefined}
+        onMouseEnter={onMouseEnter ? e => onMouseEnter(d, i, e) : undefined}
+        onMouseLeave={onMouseLeave ? e => onMouseLeave(d, i, e) : undefined}
+        onMouseMove={onMouseMove ? e => onMouseMove(d, i, e) : undefined}
       />
     ))}
   </React.Fragment>

--- a/src/Components/Tooltip.js
+++ b/src/Components/Tooltip.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const Tooltip = ({ visible, x, y, children }) => {
+  if (!visible) return null
+  return (
+    <div
+      className="Tooltip"
+      style={{
+        position: 'absolute',
+        left: x,
+        top: y,
+        transform: 'translate(-50%, calc(-100% - 10px))',
+        pointerEvents: 'none',
+        background: '#fff',
+        border: '1px solid #e0e0e0',
+        borderRadius: 6,
+        padding: '7px 12px',
+        fontSize: 12,
+        lineHeight: 1.6,
+        boxShadow: '0 4px 12px rgba(0,0,0,0.10)',
+        zIndex: 10,
+        whiteSpace: 'nowrap',
+        color: '#444',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+Tooltip.propTypes = {
+  visible: PropTypes.bool,
+  x: PropTypes.number,
+  y: PropTypes.number,
+  children: PropTypes.node,
+}
+
+export default Tooltip


### PR DESCRIPTION
## Summary

- Adds a `Tooltip` component — absolute-positioned HTML overlay that renders near the cursor
- All five charts (BarChart, Histogram, ScatterPlot, Timeline, PieChart) show contextual tooltips on hover
- CSS `:has()` rules dim non-hovered siblings (bars, dots, pie slices) to 35% opacity with a 150ms transition
- Timeline uses a transparent SVG overlay rect + `d3.bisect` to snap to the nearest data point, drawing a dashed hairline and dot indicator
- `Bars` and `Circles` components updated to accept `onMouseEnter(d, i, e)` / `onMouseLeave` / `onMouseMove` callbacks

### Tooltip content per chart
| Chart | Tooltip shows |
|---|---|
| BarChart | category + value |
| Histogram | bin range + count |
| ScatterPlot | x value + y value |
| Timeline | formatted date + y value |
| PieChart | label + value + % of total |

## Test plan

- [ ] Run `npm test` — all 72 tests pass
- [ ] Hover over bars in BarChart — tooltip appears, non-hovered bars dim
- [ ] Hover over bars in Histogram — tooltip shows bin range and count
- [ ] Hover over dots in ScatterPlot — tooltip appears, other dots dim
- [ ] Move mouse over Timeline — hairline snaps to nearest data point, tooltip updates
- [ ] Hover over pie slices — tooltip shows label, value, and percentage; other slices dim
- [ ] Tooltip stays within chart bounds on edge data points
