### PR TITLE
Add StackedBarChart component

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A lightweight React + D3 chart library for building responsive, accessible data 
 - **ScatterPlot** — correlation scatter chart
 - **Histogram** — frequency distribution chart
 - **BarChart** — categorical bar chart
+- **StackedBarChart** — stacked bar chart for part-to-whole across categories
 - **PieChart** — pie / donut chart for part-to-whole comparisons
 
 ## Installation
@@ -201,6 +202,46 @@ const data = [
 | `legendPosition` | `'top'\|'bottom'\|'left'\|'right'` | `'bottom'` | Position of the legend relative to the chart |
 
 ![Bar chart with legend](docs/barchart-legend.png)
+
+---
+
+### StackedBarChart
+
+Renders a stacked vertical bar chart for comparing part-to-whole relationships across categories. Pass a `keys` array and each key must be a numeric property on every datum.
+
+```jsx
+import { StackedBarChart } from 'quick-charts'
+
+const data = [
+  { month: 'Jan', apples: 30, oranges: 20, bananas: 15 },
+  { month: 'Feb', apples: 25, oranges: 30, bananas: 10 },
+  { month: 'Mar', apples: 40, oranges: 15, bananas: 20 },
+  { month: 'Apr', apples: 35, oranges: 25, bananas: 18 },
+]
+
+<div style={{ width: 560, height: 340 }}>
+  <StackedBarChart
+    data={data}
+    xAccessor={d => d.month}
+    keys={['apples', 'oranges', 'bananas']}
+    xLabel="Month"
+    yLabel="Units"
+  />
+</div>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `data` | `Array` | — | Array of data objects |
+| `xAccessor` | `Function` | `d => d.x` | Returns a category string from each datum |
+| `keys` | `String[]` | — | **Required.** Series keys to stack — each must be a numeric property on every datum |
+| `colors` | `String[]` | `d3.schemeSet2` | One color per key |
+| `xLabel` | `String` | — | Label for the x-axis |
+| `yLabel` | `String` | — | Label for the y-axis |
+| `barPadding` | `Number` | `0.2` | Fractional gap between bar groups (0–1) |
+| `formatYTick` | `Function` | `d3.format(",")` | Custom y-axis tick label formatter |
+| `showLegend` | `Boolean` | `true` | Show a legend with one entry per key |
+| `legendPosition` | `'top'\|'bottom'\|'left'\|'right'` | `'bottom'` | Position of the legend relative to the chart |
 
 ---
 

--- a/src/Charts/StackedBarChart.js
+++ b/src/Charts/StackedBarChart.js
@@ -1,0 +1,126 @@
+import React, { useRef, useState } from "react"
+import PropTypes from "prop-types"
+import * as d3 from "d3"
+
+import Chart from "../Components/Chart"
+import Axis from "../Cartesian/Axis"
+import Legend from "../Components/Legend"
+import Tooltip from "../Components/Tooltip"
+import { useChartDimensions, accessorPropsType } from "../Utils/utils"
+
+const fmt = d3.format(",")
+
+const StackedBarChart = ({
+  data, xAccessor, keys, colors,
+  xLabel, yLabel, barPadding, formatYTick,
+  showLegend, legendPosition,
+}) => {
+  const [ref, dimensions] = useChartDimensions({ marginBottom: 77 })
+  const wrapperRef = useRef()
+  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0, key: null, value: 0, category: null, total: 0 })
+
+  if (!data || data.length === 0 || !keys || keys.length === 0) return null
+
+  const colorScale = d3.scaleOrdinal(Array.isArray(colors) ? colors : d3.schemeSet2).domain(keys)
+
+  const series = d3.stack().keys(keys)(data)
+
+  const xScale = d3.scaleBand()
+    .domain(data.map(xAccessor))
+    .range([0, dimensions.boundedWidth])
+    .padding(barPadding !== undefined ? barPadding : 0.2)
+
+  const yScale = d3.scaleLinear()
+    .domain([0, d3.max(series, s => d3.max(s, d => d[1]))])
+    .range([dimensions.boundedHeight, 0])
+    .nice()
+
+  const getPos = e => {
+    const { left, top } = wrapperRef.current.getBoundingClientRect()
+    return { x: e.clientX - left, y: e.clientY - top }
+  }
+
+  const handleEnter = (key, d, e) => {
+    const { x, y } = getPos(e)
+    const total = keys.reduce((sum, k) => sum + (d.data[k] || 0), 0)
+    setTooltip({ visible: true, x, y, key, value: d[1] - d[0], category: xAccessor(d.data), total })
+  }
+  const handleMove = (key, d, e) => {
+    const { x, y } = getPos(e)
+    setTooltip(t => ({ ...t, x, y }))
+  }
+  const handleLeave = () => setTooltip(t => ({ ...t, visible: false }))
+
+  const legendItems = keys.map(k => ({ color: colorScale(k), label: k }))
+  const resolvedPosition = legendPosition || 'bottom'
+  const isHorizontal = resolvedPosition === 'left' || resolvedPosition === 'right'
+  const isLeading = resolvedPosition === 'top' || resolvedPosition === 'left'
+
+  const chart = (
+    <div className="StackedBarChart" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
+      <Chart dimensions={dimensions} label={[xLabel, yLabel].filter(Boolean).join(' / ')}>
+        <Axis dimension="x" scale={xScale} formatTick={d => d} label={xLabel} />
+        <Axis dimension="y" scale={yScale} formatTick={formatYTick} label={yLabel} />
+        {series.map(s => (
+          <g key={s.key} className="StackedBar__series">
+            {s.map((d, i) => (
+              <rect
+                key={i}
+                className="StackedBar__segment"
+                x={xScale(xAccessor(d.data))}
+                y={yScale(d[1])}
+                width={xScale.bandwidth()}
+                height={Math.max(0, yScale(d[0]) - yScale(d[1]))}
+                style={{ fill: colorScale(s.key) }}
+                onMouseEnter={e => handleEnter(s.key, d, e)}
+                onMouseMove={e => handleMove(s.key, d, e)}
+                onMouseLeave={handleLeave}
+              />
+            ))}
+          </g>
+        ))}
+      </Chart>
+    </div>
+  )
+
+  const legend = showLegend !== false && legendItems.length > 0
+    ? <Legend items={legendItems} position={resolvedPosition} />
+    : null
+
+  return (
+    <div ref={wrapperRef} style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column', position: 'relative' }}>
+      {isLeading && legend}
+      {chart}
+      {!isLeading && legend}
+      <Tooltip visible={tooltip.visible} x={tooltip.x} y={tooltip.y}>
+        {tooltip.key && (
+          <>
+            <div><strong>{tooltip.category}</strong></div>
+            <div>{tooltip.key}: {fmt(tooltip.value)}</div>
+            <div style={{ color: '#888', fontSize: 11 }}>Total: {fmt(tooltip.total)}</div>
+          </>
+        )}
+      </Tooltip>
+    </div>
+  )
+}
+
+StackedBarChart.propTypes = {
+  data: PropTypes.array,
+  xAccessor: accessorPropsType,
+  /** Series keys to stack — each key must be a numeric property on each datum. Required. */
+  keys: PropTypes.arrayOf(PropTypes.string).isRequired,
+  colors: PropTypes.arrayOf(PropTypes.string),
+  xLabel: PropTypes.string,
+  yLabel: PropTypes.string,
+  barPadding: PropTypes.number,
+  formatYTick: PropTypes.func,
+  showLegend: PropTypes.bool,
+  legendPosition: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
+}
+
+StackedBarChart.defaultProps = {
+  xAccessor: d => d.x,
+}
+
+export default StackedBarChart

--- a/src/Charts/index.js
+++ b/src/Charts/index.js
@@ -2,5 +2,6 @@ export {default as BarChart} from './BarChart';
 export {default as Histogram} from './Histogram';
 export {default as PieChart} from './PieChart';
 export {default as ScatterPlot} from './ScatterPlot';
+export {default as StackedBarChart} from './StackedBarChart';
 export {default as Timeline} from './Timeline';
 

--- a/src/Components/Chart.css
+++ b/src/Components/Chart.css
@@ -77,6 +77,15 @@
     opacity: 0.35;
 }
 
+.StackedBar__segment {
+    transition: opacity 0.15s ease-out;
+    cursor: pointer;
+}
+
+.StackedBarChart:has(.StackedBar__segment:hover) .StackedBar__segment:not(:hover) {
+    opacity: 0.35;
+}
+
 /* Timeline hover elements */
 .Timeline__hover-line {
     stroke: #aaa;

--- a/src/__tests__/StackedBarChart.test.js
+++ b/src/__tests__/StackedBarChart.test.js
@@ -1,0 +1,82 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import StackedBarChart from '../Charts/StackedBarChart'
+
+const keys = ['apples', 'oranges', 'bananas']
+
+const makeData = () => [
+  { month: 'Jan', apples: 30, oranges: 20, bananas: 15 },
+  { month: 'Feb', apples: 25, oranges: 30, bananas: 10 },
+  { month: 'Mar', apples: 40, oranges: 15, bananas: 20 },
+  { month: 'Apr', apples: 35, oranges: 25, bananas: 18 },
+]
+
+const baseProps = {
+  data: makeData(),
+  xAccessor: d => d.month,
+  keys,
+}
+
+describe('StackedBarChart', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<StackedBarChart {...baseProps} />)
+    expect(container.firstChild).toBeInTheDocument()
+  })
+
+  it('renders a .StackedBarChart container', () => {
+    const { container } = render(<StackedBarChart {...baseProps} />)
+    expect(container.querySelector('.StackedBarChart')).toBeInTheDocument()
+  })
+
+  it('renders an SVG chart', () => {
+    const { container } = render(<StackedBarChart {...baseProps} />)
+    expect(container.querySelector('svg.Chart')).toBeInTheDocument()
+  })
+
+  it('renders one segment per datum per key', () => {
+    const data = makeData()
+    const { container } = render(<StackedBarChart {...baseProps} data={data} />)
+    expect(container.querySelectorAll('.StackedBar__segment')).toHaveLength(data.length * keys.length)
+  })
+
+  it('renders one series group per key', () => {
+    const { container } = render(<StackedBarChart {...baseProps} />)
+    expect(container.querySelectorAll('.StackedBar__series')).toHaveLength(keys.length)
+  })
+
+  it('renders x and y axes', () => {
+    const { container } = render(<StackedBarChart {...baseProps} />)
+    expect(container.querySelector('.AxisHorizontal')).toBeInTheDocument()
+    expect(container.querySelector('.AxisVertical')).toBeInTheDocument()
+  })
+
+  it('renders nothing for empty data', () => {
+    const { container } = render(<StackedBarChart data={[]} keys={keys} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when keys is empty', () => {
+    const { container } = render(<StackedBarChart data={makeData()} keys={[]} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows a legend by default', () => {
+    const { container } = render(<StackedBarChart {...baseProps} />)
+    expect(container.querySelector('.Legend')).toBeInTheDocument()
+  })
+
+  it('legend has one item per key', () => {
+    const { container } = render(<StackedBarChart {...baseProps} />)
+    expect(container.querySelectorAll('.Legend__item')).toHaveLength(keys.length)
+  })
+
+  it('hides legend when showLegend is false', () => {
+    const { container } = render(<StackedBarChart {...baseProps} showLegend={false} />)
+    expect(container.querySelector('.Legend')).not.toBeInTheDocument()
+  })
+
+  it('uses default xAccessor (d => d.x)', () => {
+    const defaultData = makeData().map(d => ({ x: d.month, ...d }))
+    expect(() => render(<StackedBarChart data={defaultData} keys={keys} />)).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a `StackedBarChart` component using `d3.stack()` to layer multiple numeric series per category
- Accepts a required `keys` array — each key must be a numeric property on every datum
- Tooltip on hover shows category name, hovered series value, and the bar total
- Non-hovered segments dim to 35% opacity via CSS `:has()` rules
- Legend is shown by default (one swatch per key); supports all four `legendPosition` values
- README updated with usage example and full prop table

## Test plan

- [x] Run `npm test` — all 84 tests pass (12 new StackedBarChart tests)
- [x] Verify segments render: `data.length × keys.length` rects total
- [x] Hover a segment — tooltip shows category, series value, and bar total
- [x] Non-hovered segments dim; moving to another segment updates tooltip
- [x] `showLegend={false}` hides the legend
- [x] Empty `data` or empty `keys` renders nothing