### PR TITLE
Refactor: extract shared hooks/components, add memoization

### DIFF
--- a/src/Charts/BarChart.js
+++ b/src/Charts/BarChart.js
@@ -1,13 +1,14 @@
-import React, { useRef, useState } from "react"
+import React, { useCallback, useMemo } from "react"
 import PropTypes from "prop-types"
 import * as d3 from "d3"
 
 import Chart from "../Components/Chart"
 import Bars from "../Components/Bars"
 import Axis from "../Cartesian/Axis"
-import Legend from "../Components/Legend"
+import ChartLayout from "../Components/ChartLayout"
 import Tooltip from "../Components/Tooltip"
 import { useChartDimensions, accessorPropsType } from "../Utils/utils"
+import { useTooltip } from "../Utils/useTooltip"
 
 const DEFAULT_COLOR = '#9980FA'
 const fmt = d3.format(",")
@@ -18,79 +19,43 @@ const BarChart = ({
   showLegend, legendPosition,
 }) => {
   const [ref, dimensions] = useChartDimensions({ marginBottom: 77 })
-  const wrapperRef = useRef()
-  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0, d: null })
+  const { wrapperRef, tooltip, showTooltip, moveTooltip, hideTooltip } = useTooltip()
+
+  const xScale = useMemo(() =>
+    d3.scaleBand()
+      .domain(data ? data.map(xAccessor) : [])
+      .range([0, dimensions.boundedWidth])
+      .padding(barPadding ?? 0.2),
+    [data, xAccessor, dimensions.boundedWidth, barPadding]
+  )
+
+  const yScale = useMemo(() =>
+    d3.scaleLinear()
+      .domain([yMin ?? 0, d3.max(data, yAccessor) || 0])
+      .range([dimensions.boundedHeight, 0])
+      .nice(),
+    [data, yAccessor, dimensions.boundedHeight, yMin]
+  )
+
+  const legendItems = useMemo(() =>
+    yLabel ? [{ color: color || DEFAULT_COLOR, label: yLabel }] : [],
+    [yLabel, color]
+  )
+
+  const barStyle = useMemo(() => color ? { fill: color } : undefined, [color])
+
+  const handleEnter = useCallback((d, i, e) => showTooltip(e, { d }), [showTooltip])
+  const handleMove = useCallback((d, i, e) => moveTooltip(e), [moveTooltip])
 
   if (!data || data.length === 0) return null
-
-  const xScale = d3.scaleBand()
-    .domain(data.map(xAccessor))
-    .range([0, dimensions.boundedWidth])
-    .padding(barPadding !== undefined ? barPadding : 0.2)
-
-  const yScale = d3.scaleLinear()
-    .domain([yMin !== undefined ? yMin : 0, d3.max(data, yAccessor)])
-    .range([dimensions.boundedHeight, 0])
-    .nice()
 
   const xAccessorScaled = d => xScale(xAccessor(d))
   const yAccessorScaled = d => yScale(yAccessor(d))
   const widthAccessorScaled = () => xScale.bandwidth()
   const heightAccessorScaled = d => dimensions.boundedHeight - yScale(yAccessor(d))
-  const keyAccessor = (d, i) => i
-
-  const getPos = e => {
-    const { left, top } = wrapperRef.current.getBoundingClientRect()
-    return { x: e.clientX - left, y: e.clientY - top }
-  }
-
-  const handleEnter = (d, i, e) => {
-    const { x, y } = getPos(e)
-    setTooltip({ visible: true, x, y, d })
-  }
-  const handleMove = (d, i, e) => {
-    const { x, y } = getPos(e)
-    setTooltip(t => ({ ...t, x, y }))
-  }
-  const handleLeave = () => setTooltip(t => ({ ...t, visible: false }))
-
-  const legendItems = yLabel
-    ? [{ color: color || DEFAULT_COLOR, label: yLabel }]
-    : []
-  const resolvedPosition = legendPosition || 'bottom'
-  const isHorizontal = resolvedPosition === 'left' || resolvedPosition === 'right'
-  const isLeading = resolvedPosition === 'top' || resolvedPosition === 'left'
-
-  const chart = (
-    <div className="BarChart" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
-      <Chart dimensions={dimensions} label={[xLabel, yLabel].filter(Boolean).join(' / ')}>
-        <Axis dimension="x" scale={xScale} formatTick={d => d} label={xLabel} />
-        <Axis dimension="y" scale={yScale} formatTick={formatYTick} label={yLabel} />
-        <Bars
-          data={data}
-          keyAccessor={keyAccessor}
-          xAccessor={xAccessorScaled}
-          yAccessor={yAccessorScaled}
-          widthAccessor={widthAccessorScaled}
-          heightAccessor={heightAccessorScaled}
-          style={color ? { fill: color } : undefined}
-          onMouseEnter={handleEnter}
-          onMouseMove={handleMove}
-          onMouseLeave={handleLeave}
-        />
-      </Chart>
-    </div>
-  )
-
-  const legend = showLegend && legendItems.length > 0
-    ? <Legend items={legendItems} position={resolvedPosition} />
-    : null
 
   return (
-    <div ref={wrapperRef} style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column', position: 'relative' }}>
-      {isLeading && legend}
-      {chart}
-      {!isLeading && legend}
+    <ChartLayout wrapperRef={wrapperRef} legendItems={legendItems} showLegend={showLegend} legendPosition={legendPosition} tooltip={
       <Tooltip visible={tooltip.visible} x={tooltip.x} y={tooltip.y}>
         {tooltip.d && (
           <>
@@ -99,7 +64,26 @@ const BarChart = ({
           </>
         )}
       </Tooltip>
-    </div>
+    }>
+      <div className="BarChart" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
+        <Chart dimensions={dimensions} label={[xLabel, yLabel].filter(Boolean).join(' / ')}>
+          <Axis dimension="x" scale={xScale} formatTick={d => d} label={xLabel} />
+          <Axis dimension="y" scale={yScale} formatTick={formatYTick} label={yLabel} />
+          <Bars
+            data={data}
+            keyAccessor={(d, i) => i}
+            xAccessor={xAccessorScaled}
+            yAccessor={yAccessorScaled}
+            widthAccessor={widthAccessorScaled}
+            heightAccessor={heightAccessorScaled}
+            style={barStyle}
+            onMouseEnter={handleEnter}
+            onMouseMove={handleMove}
+            onMouseLeave={hideTooltip}
+          />
+        </Chart>
+      </div>
+    </ChartLayout>
   )
 }
 

--- a/src/Charts/Histogram.js
+++ b/src/Charts/Histogram.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react"
+import React, { useCallback, useMemo } from "react"
 import PropTypes from "prop-types"
 import * as d3 from "d3"
 
@@ -6,114 +6,78 @@ import Chart from "../Components/Chart"
 import Bars from "../Components/Bars"
 import Axis from "../Cartesian/Axis"
 import Gradient from "../Components/Gradient"
-import Legend from "../Components/Legend"
+import ChartLayout from "../Components/ChartLayout"
 import Tooltip from "../Components/Tooltip"
 import { useChartDimensions, accessorPropsType, useUniqueId } from "../Utils/utils"
+import { useTooltip } from "../Utils/useTooltip"
 
-const defaultGradientColors = ["#9980FA", "rgb(226, 222, 243)"]
+const DEFAULT_GRADIENT = ["#9980FA", "rgb(226, 222, 243)"]
 const DEFAULT_COLOR = '#9980FA'
 const fmt = d3.format(",")
 const fmtFixed = d3.format(",.2~f")
+const BAR_PADDING = 2
 
 const Histogram = ({
   data, xAccessor, xLabel, yLabel,
-  color, gradientColors: gradientColorsProp, thresholds,
+  color, gradientColors, thresholds,
   formatXTick, formatYTick,
   showLegend, legendPosition,
 }) => {
   const gradientId = useUniqueId("Histogram-gradient")
   const [ref, dimensions] = useChartDimensions({ marginBottom: 77 })
-  const wrapperRef = useRef()
-  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0, d: null })
-
-  if (!data || data.length === 0) return null
+  const { wrapperRef, tooltip, showTooltip, moveTooltip, hideTooltip } = useTooltip()
 
   const numberOfThresholds = thresholds || 9
 
-  const xScale = d3.scaleLinear()
-    .domain(d3.extent(data, xAccessor))
-    .range([0, dimensions.boundedWidth])
-    .nice(numberOfThresholds)
+  const xScale = useMemo(() =>
+    d3.scaleLinear()
+      .domain(d3.extent(data, xAccessor))
+      .range([0, dimensions.boundedWidth])
+      .nice(numberOfThresholds),
+    [data, xAccessor, dimensions.boundedWidth, numberOfThresholds]
+  )
 
-  const binsGenerator = d3.histogram()
-    .domain(xScale.domain())
-    .value(xAccessor)
-    .thresholds(xScale.ticks(numberOfThresholds))
+  const bins = useMemo(() =>
+    d3.histogram()
+      .domain(xScale.domain())
+      .value(xAccessor)
+      .thresholds(xScale.ticks(numberOfThresholds))(data),
+    [xScale, xAccessor, numberOfThresholds, data]
+  )
 
-  const bins = binsGenerator(data)
-  const yAccessor = d => d.length
-  const yScale = d3.scaleLinear()
-    .domain([0, d3.max(bins, yAccessor)])
-    .range([dimensions.boundedHeight, 0])
-    .nice()
+  const yScale = useMemo(() =>
+    d3.scaleLinear()
+      .domain([0, d3.max(bins, d => d.length) || 0])
+      .range([dimensions.boundedHeight, 0])
+      .nice(),
+    [bins, dimensions.boundedHeight]
+  )
 
-  const barPadding = 2
-  const xAccessorScaled = d => xScale(d.x0) + barPadding
-  const yAccessorScaled = d => yScale(yAccessor(d))
-  const widthAccessorScaled = d => xScale(d.x1) - xScale(d.x0) - barPadding
-  const heightAccessorScaled = d => dimensions.boundedHeight - yScale(yAccessor(d))
-  const keyAccessor = (d, i) => i
+  const legendItems = useMemo(() =>
+    xLabel ? [{ color: color || DEFAULT_COLOR, label: xLabel }] : [],
+    [xLabel, color]
+  )
 
-  const resolvedGradientColors = gradientColorsProp || defaultGradientColors
-  const barStyle = color ? { fill: color } : { fill: `url(#${gradientId})` }
+  const resolvedGradientColors = gradientColors || DEFAULT_GRADIENT
+  const barStyle = useMemo(() =>
+    color ? { fill: color } : { fill: `url(#${gradientId})` },
+    [color, gradientId]
+  )
 
   const tickFmt = formatXTick || fmtFixed
 
-  const getPos = e => {
-    const { left, top } = wrapperRef.current.getBoundingClientRect()
-    return { x: e.clientX - left, y: e.clientY - top }
-  }
+  const handleEnter = useCallback((d, i, e) => showTooltip(e, { d }), [showTooltip])
+  const handleMove = useCallback((d, i, e) => moveTooltip(e), [moveTooltip])
 
-  const handleEnter = (d, i, e) => {
-    const { x, y } = getPos(e)
-    setTooltip({ visible: true, x, y, d })
-  }
-  const handleMove = (d, i, e) => {
-    const { x, y } = getPos(e)
-    setTooltip(t => ({ ...t, x, y }))
-  }
-  const handleLeave = () => setTooltip(t => ({ ...t, visible: false }))
+  if (!data || data.length === 0) return null
 
-  const legendItems = xLabel
-    ? [{ color: color || DEFAULT_COLOR, label: xLabel }]
-    : []
-  const resolvedPosition = legendPosition || 'bottom'
-  const isHorizontal = resolvedPosition === 'left' || resolvedPosition === 'right'
-  const isLeading = resolvedPosition === 'top' || resolvedPosition === 'left'
-
-  const chart = (
-    <div className="Histogram" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
-      <Chart dimensions={dimensions} label={[xLabel, yLabel].filter(Boolean).join(' / ')}>
-        <defs>
-          <Gradient id={gradientId} colors={resolvedGradientColors} x2="0" y2="100%" />
-        </defs>
-        <Axis dimension="x" scale={xScale} formatTick={formatXTick} label={xLabel} />
-        <Axis dimension="y" scale={yScale} formatTick={formatYTick} label={yLabel || "Count"} />
-        <Bars
-          data={bins}
-          keyAccessor={keyAccessor}
-          xAccessor={xAccessorScaled}
-          yAccessor={yAccessorScaled}
-          widthAccessor={widthAccessorScaled}
-          heightAccessor={heightAccessorScaled}
-          style={barStyle}
-          onMouseEnter={handleEnter}
-          onMouseMove={handleMove}
-          onMouseLeave={handleLeave}
-        />
-      </Chart>
-    </div>
-  )
-
-  const legend = showLegend && legendItems.length > 0
-    ? <Legend items={legendItems} position={resolvedPosition} />
-    : null
+  const xAccessorScaled = d => xScale(d.x0) + BAR_PADDING
+  const yAccessorScaled = d => yScale(d.length)
+  const widthAccessorScaled = d => xScale(d.x1) - xScale(d.x0) - BAR_PADDING
+  const heightAccessorScaled = d => dimensions.boundedHeight - yScale(d.length)
 
   return (
-    <div ref={wrapperRef} style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column', position: 'relative' }}>
-      {isLeading && legend}
-      {chart}
-      {!isLeading && legend}
+    <ChartLayout wrapperRef={wrapperRef} legendItems={legendItems} showLegend={showLegend} legendPosition={legendPosition} tooltip={
       <Tooltip visible={tooltip.visible} x={tooltip.x} y={tooltip.y}>
         {tooltip.d && (
           <>
@@ -122,7 +86,29 @@ const Histogram = ({
           </>
         )}
       </Tooltip>
-    </div>
+    }>
+      <div className="Histogram" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
+        <Chart dimensions={dimensions} label={[xLabel, yLabel].filter(Boolean).join(' / ')}>
+          <defs>
+            <Gradient id={gradientId} colors={resolvedGradientColors} x2="0" y2="100%" />
+          </defs>
+          <Axis dimension="x" scale={xScale} formatTick={formatXTick} label={xLabel} />
+          <Axis dimension="y" scale={yScale} formatTick={formatYTick} label={yLabel || "Count"} />
+          <Bars
+            data={bins}
+            keyAccessor={(d, i) => i}
+            xAccessor={xAccessorScaled}
+            yAccessor={yAccessorScaled}
+            widthAccessor={widthAccessorScaled}
+            heightAccessor={heightAccessorScaled}
+            style={barStyle}
+            onMouseEnter={handleEnter}
+            onMouseMove={handleMove}
+            onMouseLeave={hideTooltip}
+          />
+        </Chart>
+      </div>
+    </ChartLayout>
   )
 }
 

--- a/src/Charts/PieChart.js
+++ b/src/Charts/PieChart.js
@@ -1,13 +1,14 @@
-import React, { useRef, useState } from "react"
+import React, { useCallback, useMemo } from "react"
 import PropTypes from "prop-types"
 import * as d3 from "d3"
 
 import Chart from "../Components/Chart"
-import Legend from "../Components/Legend"
+import ChartLayout from "../Components/ChartLayout"
 import Tooltip from "../Components/Tooltip"
 import { useChartDimensions, accessorPropsType } from "../Utils/utils"
+import { useTooltip } from "../Utils/useTooltip"
 
-const defaultMargin = { marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20 }
+const DEFAULT_MARGIN = { marginTop: 20, marginRight: 20, marginBottom: 20, marginLeft: 20 }
 const MIN_LABEL_ANGLE = 0.35
 const fmt = d3.format(",")
 
@@ -16,118 +17,72 @@ const PieChart = ({
   colors, innerRadius, padAngle, showLabels,
   showLegend, legendPosition,
 }) => {
-  const [ref, dimensions] = useChartDimensions(defaultMargin)
-  const wrapperRef = useRef()
-  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0, datum: null, label: null })
+  const [ref, dimensions] = useChartDimensions(DEFAULT_MARGIN)
+  const { wrapperRef, tooltip, showTooltip, moveTooltip, hideTooltip } = useTooltip()
 
-  if (!data || data.length === 0) return null
+  const colorScale = useMemo(() =>
+    d3.scaleOrdinal(Array.isArray(colors) ? colors : d3.schemeSet2),
+    [colors]
+  )
 
   const outerRadius = Math.min(dimensions.boundedWidth, dimensions.boundedHeight) / 2
   const cx = dimensions.boundedWidth / 2
   const cy = dimensions.boundedHeight / 2
 
-  const colorScale = d3.scaleOrdinal(
-    Array.isArray(colors) ? colors : d3.schemeSet2
-  )
-
   const resolvedInnerRadius = typeof innerRadius === 'number'
     ? outerRadius * Math.min(Math.max(innerRadius, 0), 0.95)
     : 0
 
-  const pieGenerator = d3.pie()
-    .value(valueAccessor)
-    .padAngle(padAngle !== undefined ? padAngle : 0.02)
-    .sort(null)
-
-  const arcGenerator = d3.arc()
-    .innerRadius(resolvedInnerRadius)
-    .outerRadius(outerRadius)
-
-  const labelRadius = resolvedInnerRadius > 0
-    ? (resolvedInnerRadius + outerRadius) / 2
-    : outerRadius * 0.65
-
-  const labelArc = d3.arc()
-    .innerRadius(labelRadius)
-    .outerRadius(labelRadius)
-
-  const arcs = pieGenerator(data)
-  const displayLabels = showLabels !== false && typeof labelAccessor === 'function'
-
-  const total = d3.sum(data, valueAccessor)
-
-  const legendItems = typeof labelAccessor === 'function'
-    ? data.map((d, i) => {
-        const label = labelAccessor(d)
-        return { color: colorScale(label !== undefined ? label : String(i)), label: String(label) }
-      })
-    : []
-
-  const resolvedPosition = legendPosition || 'bottom'
-  const isHorizontal = resolvedPosition === 'left' || resolvedPosition === 'right'
-  const isLeading = resolvedPosition === 'top' || resolvedPosition === 'left'
-
-  const getPos = e => {
-    const { left, top } = wrapperRef.current.getBoundingClientRect()
-    return { x: e.clientX - left, y: e.clientY - top }
-  }
-
-  const handleSliceEnter = (datum, label, e) => {
-    const { x, y } = getPos(e)
-    setTooltip({ visible: true, x, y, datum, label })
-  }
-  const handleSliceMove = (datum, label, e) => {
-    const { x, y } = getPos(e)
-    setTooltip(t => ({ ...t, x, y }))
-  }
-  const handleSliceLeave = () => setTooltip(t => ({ ...t, visible: false }))
-
-  const chart = (
-    <div className="PieChart" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
-      <Chart dimensions={dimensions} label="Pie chart">
-        <g transform={`translate(${cx}, ${cy})`}>
-          {arcs.map((arc, i) => {
-            const label = labelAccessor ? labelAccessor(data[i]) : String(i)
-            const sliceAngle = arc.endAngle - arc.startAngle
-            return (
-              <g key={i} className="PieChart__slice-group">
-                <path
-                  className="PieChart__slice"
-                  d={arcGenerator(arc)}
-                  style={{ fill: colorScale(label) }}
-                  onMouseEnter={e => handleSliceEnter(data[i], label, e)}
-                  onMouseMove={e => handleSliceMove(data[i], label, e)}
-                  onMouseLeave={handleSliceLeave}
-                />
-                {displayLabels && sliceAngle >= MIN_LABEL_ANGLE && (
-                  <text
-                    className="PieChart__label"
-                    transform={`translate(${labelArc.centroid(arc)})`}
-                    style={{ textAnchor: 'middle', dominantBaseline: 'middle', pointerEvents: 'none' }}
-                  >
-                    {label}
-                  </text>
-                )}
-              </g>
-            )
-          })}
-        </g>
-      </Chart>
-    </div>
+  const arcGenerator = useMemo(() =>
+    d3.arc().innerRadius(resolvedInnerRadius).outerRadius(outerRadius),
+    [resolvedInnerRadius, outerRadius]
   )
 
-  const legend = showLegend && legendItems.length > 0
-    ? <Legend items={legendItems} position={resolvedPosition} />
-    : null
+  const labelArc = useMemo(() => {
+    const r = resolvedInnerRadius > 0
+      ? (resolvedInnerRadius + outerRadius) / 2
+      : outerRadius * 0.65
+    return d3.arc().innerRadius(r).outerRadius(r)
+  }, [resolvedInnerRadius, outerRadius])
 
+  const arcs = useMemo(() =>
+    data ? d3.pie()
+      .value(valueAccessor)
+      .padAngle(padAngle ?? 0.02)
+      .sort(null)(data)
+    : [],
+    [data, valueAccessor, padAngle]
+  )
+
+  const total = useMemo(() =>
+    data ? d3.sum(data, valueAccessor) : 0,
+    [data, valueAccessor]
+  )
+
+  const legendItems = useMemo(() =>
+    typeof labelAccessor === 'function'
+      ? (data || []).map((d, i) => {
+          const label = labelAccessor(d)
+          return { color: colorScale(label !== undefined ? label : String(i)), label: String(label) }
+        })
+      : [],
+    [data, labelAccessor, colorScale]
+  )
+
+  const handleSliceEnter = useCallback((datum, label, e) =>
+    showTooltip(e, { datum, label }),
+    [showTooltip]
+  )
+  const handleSliceMove = useCallback((datum, label, e) => moveTooltip(e), [moveTooltip])
+
+  if (!data || data.length === 0) return null
+
+  const displayLabels = showLabels !== false && typeof labelAccessor === 'function'
   const tooltipValue = tooltip.datum ? valueAccessor(tooltip.datum) : 0
   const tooltipPct = total > 0 ? Math.round(tooltipValue / total * 100) : 0
 
   return (
-    <div ref={wrapperRef} style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column', position: 'relative' }}>
-      {isLeading && legend}
-      {chart}
-      {!isLeading && legend}
+    <ChartLayout wrapperRef={wrapperRef} legendItems={legendItems} showLegend={showLegend} legendPosition={legendPosition} tooltip={
       <Tooltip visible={tooltip.visible} x={tooltip.x} y={tooltip.y}>
         {tooltip.datum && (
           <>
@@ -136,7 +91,38 @@ const PieChart = ({
           </>
         )}
       </Tooltip>
-    </div>
+    }>
+      <div className="PieChart" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
+        <Chart dimensions={dimensions} label="Pie chart">
+          <g transform={`translate(${cx}, ${cy})`}>
+            {arcs.map((arc, i) => {
+              const label = labelAccessor ? labelAccessor(data[i]) : String(i)
+              return (
+                <g key={i} className="PieChart__slice-group">
+                  <path
+                    className="PieChart__slice"
+                    d={arcGenerator(arc)}
+                    style={{ fill: colorScale(label) }}
+                    onMouseEnter={e => handleSliceEnter(data[i], label, e)}
+                    onMouseMove={e => handleSliceMove(data[i], label, e)}
+                    onMouseLeave={hideTooltip}
+                  />
+                  {displayLabels && (arc.endAngle - arc.startAngle) >= MIN_LABEL_ANGLE && (
+                    <text
+                      className="PieChart__label"
+                      transform={`translate(${labelArc.centroid(arc)})`}
+                      style={{ textAnchor: 'middle', dominantBaseline: 'middle', pointerEvents: 'none' }}
+                    >
+                      {label}
+                    </text>
+                  )}
+                </g>
+              )
+            })}
+          </g>
+        </Chart>
+      </div>
+    </ChartLayout>
   )
 }
 
@@ -148,9 +134,7 @@ PieChart.propTypes = {
   innerRadius: PropTypes.number,
   padAngle: PropTypes.number,
   showLabels: PropTypes.bool,
-  /** Show a legend listing each slice's color and label. Default: false. */
   showLegend: PropTypes.bool,
-  /** Position of the legend. One of 'top', 'bottom', 'left', 'right'. Default: 'bottom'. */
   legendPosition: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
 }
 

--- a/src/Charts/ScatterPlot.js
+++ b/src/Charts/ScatterPlot.js
@@ -1,13 +1,14 @@
-import React, { useRef, useState } from "react"
+import React, { useCallback, useMemo } from "react"
 import PropTypes from "prop-types"
 import * as d3 from "d3"
 
 import Chart from "../Components/Chart"
 import Circles from "../Components/Circles"
 import Axis from "../Cartesian/Axis"
-import Legend from "../Components/Legend"
+import ChartLayout from "../Components/ChartLayout"
 import Tooltip from "../Components/Tooltip"
 import { useChartDimensions, accessorPropsType } from "../Utils/utils"
+import { useTooltip } from "../Utils/useTooltip"
 
 const DEFAULT_COLOR = '#9980FA'
 const fmt = d3.format(",")
@@ -18,79 +19,35 @@ const ScatterPlot = ({
   showLegend, legendPosition,
 }) => {
   const [ref, dimensions] = useChartDimensions({ marginBottom: 77 })
-  const wrapperRef = useRef()
-  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0, d: null })
+  const { wrapperRef, tooltip, showTooltip, moveTooltip, hideTooltip } = useTooltip()
+
+  const xScale = useMemo(() => {
+    const extent = d3.extent(data, xAccessor)
+    const domain = extent[0] === extent[1] ? [extent[0] - 1, extent[0] + 1] : extent
+    return d3.scaleLinear().domain(domain).range([0, dimensions.boundedWidth]).nice()
+  }, [data, xAccessor, dimensions.boundedWidth])
+
+  const yScale = useMemo(() => {
+    const extent = d3.extent(data, yAccessor)
+    const domain = extent[0] === extent[1] ? [extent[0] - 1, extent[0] + 1] : extent
+    return d3.scaleLinear().domain(domain).range([dimensions.boundedHeight, 0]).nice()
+  }, [data, yAccessor, dimensions.boundedHeight])
+
+  const legendItems = useMemo(() =>
+    yLabel ? [{ color: color || DEFAULT_COLOR, label: yLabel }] : [],
+    [yLabel, color]
+  )
+
+  const handleEnter = useCallback((d, i, e) => showTooltip(e, { d }), [showTooltip])
+  const handleMove = useCallback((d, i, e) => moveTooltip(e), [moveTooltip])
 
   if (!data || data.length === 0) return null
 
-  const xExtent = d3.extent(data, xAccessor)
-  const yExtent = d3.extent(data, yAccessor)
-
-  const xDomain = xExtent[0] === xExtent[1]
-    ? [xExtent[0] - 1, xExtent[0] + 1]
-    : xExtent
-  const yDomain = yExtent[0] === yExtent[1]
-    ? [yExtent[0] - 1, yExtent[0] + 1]
-    : yExtent
-
-  const xScale = d3.scaleLinear().domain(xDomain).range([0, dimensions.boundedWidth]).nice()
-  const yScale = d3.scaleLinear().domain(yDomain).range([dimensions.boundedHeight, 0]).nice()
-
   const xAccessorScaled = d => xScale(xAccessor(d))
   const yAccessorScaled = d => yScale(yAccessor(d))
-  const keyAccessor = (d, i) => i
-
-  const getPos = e => {
-    const { left, top } = wrapperRef.current.getBoundingClientRect()
-    return { x: e.clientX - left, y: e.clientY - top }
-  }
-
-  const handleEnter = (d, i, e) => {
-    const { x, y } = getPos(e)
-    setTooltip({ visible: true, x, y, d })
-  }
-  const handleMove = (d, i, e) => {
-    const { x, y } = getPos(e)
-    setTooltip(t => ({ ...t, x, y }))
-  }
-  const handleLeave = () => setTooltip(t => ({ ...t, visible: false }))
-
-  const legendItems = yLabel
-    ? [{ color: color || DEFAULT_COLOR, label: yLabel }]
-    : []
-  const resolvedPosition = legendPosition || 'bottom'
-  const isHorizontal = resolvedPosition === 'left' || resolvedPosition === 'right'
-  const isLeading = resolvedPosition === 'top' || resolvedPosition === 'left'
-
-  const chart = (
-    <div className="ScatterPlot" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
-      <Chart dimensions={dimensions} label={[xLabel, yLabel].filter(Boolean).join(' / ')}>
-        <Axis dimension="x" scale={xScale} formatTick={formatXTick} label={xLabel} />
-        <Axis dimension="y" scale={yScale} formatTick={formatYTick} label={yLabel} />
-        <Circles
-          data={data}
-          keyAccessor={keyAccessor}
-          xAccessor={xAccessorScaled}
-          yAccessor={yAccessorScaled}
-          radius={radius}
-          color={color}
-          onMouseEnter={handleEnter}
-          onMouseMove={handleMove}
-          onMouseLeave={handleLeave}
-        />
-      </Chart>
-    </div>
-  )
-
-  const legend = showLegend && legendItems.length > 0
-    ? <Legend items={legendItems} position={resolvedPosition} />
-    : null
 
   return (
-    <div ref={wrapperRef} style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column', position: 'relative' }}>
-      {isLeading && legend}
-      {chart}
-      {!isLeading && legend}
+    <ChartLayout wrapperRef={wrapperRef} legendItems={legendItems} showLegend={showLegend} legendPosition={legendPosition} tooltip={
       <Tooltip visible={tooltip.visible} x={tooltip.x} y={tooltip.y}>
         {tooltip.d && (
           <>
@@ -99,7 +56,25 @@ const ScatterPlot = ({
           </>
         )}
       </Tooltip>
-    </div>
+    }>
+      <div className="ScatterPlot" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
+        <Chart dimensions={dimensions} label={[xLabel, yLabel].filter(Boolean).join(' / ')}>
+          <Axis dimension="x" scale={xScale} formatTick={formatXTick} label={xLabel} />
+          <Axis dimension="y" scale={yScale} formatTick={formatYTick} label={yLabel} />
+          <Circles
+            data={data}
+            keyAccessor={(d, i) => i}
+            xAccessor={xAccessorScaled}
+            yAccessor={yAccessorScaled}
+            radius={radius}
+            color={color}
+            onMouseEnter={handleEnter}
+            onMouseMove={handleMove}
+            onMouseLeave={hideTooltip}
+          />
+        </Chart>
+      </div>
+    </ChartLayout>
   )
 }
 

--- a/src/Charts/StackedBarChart.js
+++ b/src/Charts/StackedBarChart.js
@@ -1,12 +1,13 @@
-import React, { useRef, useState } from "react"
+import React, { useCallback, useMemo } from "react"
 import PropTypes from "prop-types"
 import * as d3 from "d3"
 
 import Chart from "../Components/Chart"
 import Axis from "../Cartesian/Axis"
-import Legend from "../Components/Legend"
+import ChartLayout from "../Components/ChartLayout"
 import Tooltip from "../Components/Tooltip"
 import { useChartDimensions, accessorPropsType } from "../Utils/utils"
+import { useTooltip } from "../Utils/useTooltip"
 
 const fmt = d3.format(",")
 
@@ -16,82 +17,50 @@ const StackedBarChart = ({
   showLegend, legendPosition,
 }) => {
   const [ref, dimensions] = useChartDimensions({ marginBottom: 77 })
-  const wrapperRef = useRef()
-  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0, key: null, value: 0, category: null, total: 0 })
+  const { wrapperRef, tooltip, showTooltip, moveTooltip, hideTooltip } = useTooltip()
+
+  const colorScale = useMemo(() =>
+    d3.scaleOrdinal(Array.isArray(colors) ? colors : d3.schemeSet2).domain(keys),
+    [colors, keys]
+  )
+
+  const series = useMemo(() =>
+    data && keys && keys.length ? d3.stack().keys(keys)(data) : [],
+    [data, keys]
+  )
+
+  const xScale = useMemo(() =>
+    d3.scaleBand()
+      .domain(data ? data.map(xAccessor) : [])
+      .range([0, dimensions.boundedWidth])
+      .padding(barPadding ?? 0.2),
+    [data, xAccessor, dimensions.boundedWidth, barPadding]
+  )
+
+  const yScale = useMemo(() =>
+    d3.scaleLinear()
+      .domain([0, d3.max(series, s => d3.max(s, d => d[1])) || 0])
+      .range([dimensions.boundedHeight, 0])
+      .nice(),
+    [series, dimensions.boundedHeight]
+  )
+
+  const legendItems = useMemo(() =>
+    keys.map(k => ({ color: colorScale(k), label: k })),
+    [keys, colorScale]
+  )
+
+  const handleEnter = useCallback((key, d, e) => {
+    const total = keys.reduce((sum, k) => sum + (d.data[k] || 0), 0)
+    showTooltip(e, { key, value: d[1] - d[0], category: xAccessor(d.data), total })
+  }, [showTooltip, keys, xAccessor])
+
+  const handleMove = useCallback((key, d, e) => moveTooltip(e), [moveTooltip])
 
   if (!data || data.length === 0 || !keys || keys.length === 0) return null
 
-  const colorScale = d3.scaleOrdinal(Array.isArray(colors) ? colors : d3.schemeSet2).domain(keys)
-
-  const series = d3.stack().keys(keys)(data)
-
-  const xScale = d3.scaleBand()
-    .domain(data.map(xAccessor))
-    .range([0, dimensions.boundedWidth])
-    .padding(barPadding !== undefined ? barPadding : 0.2)
-
-  const yScale = d3.scaleLinear()
-    .domain([0, d3.max(series, s => d3.max(s, d => d[1]))])
-    .range([dimensions.boundedHeight, 0])
-    .nice()
-
-  const getPos = e => {
-    const { left, top } = wrapperRef.current.getBoundingClientRect()
-    return { x: e.clientX - left, y: e.clientY - top }
-  }
-
-  const handleEnter = (key, d, e) => {
-    const { x, y } = getPos(e)
-    const total = keys.reduce((sum, k) => sum + (d.data[k] || 0), 0)
-    setTooltip({ visible: true, x, y, key, value: d[1] - d[0], category: xAccessor(d.data), total })
-  }
-  const handleMove = (key, d, e) => {
-    const { x, y } = getPos(e)
-    setTooltip(t => ({ ...t, x, y }))
-  }
-  const handleLeave = () => setTooltip(t => ({ ...t, visible: false }))
-
-  const legendItems = keys.map(k => ({ color: colorScale(k), label: k }))
-  const resolvedPosition = legendPosition || 'bottom'
-  const isHorizontal = resolvedPosition === 'left' || resolvedPosition === 'right'
-  const isLeading = resolvedPosition === 'top' || resolvedPosition === 'left'
-
-  const chart = (
-    <div className="StackedBarChart" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
-      <Chart dimensions={dimensions} label={[xLabel, yLabel].filter(Boolean).join(' / ')}>
-        <Axis dimension="x" scale={xScale} formatTick={d => d} label={xLabel} />
-        <Axis dimension="y" scale={yScale} formatTick={formatYTick} label={yLabel} />
-        {series.map(s => (
-          <g key={s.key} className="StackedBar__series">
-            {s.map((d, i) => (
-              <rect
-                key={i}
-                className="StackedBar__segment"
-                x={xScale(xAccessor(d.data))}
-                y={yScale(d[1])}
-                width={xScale.bandwidth()}
-                height={Math.max(0, yScale(d[0]) - yScale(d[1]))}
-                style={{ fill: colorScale(s.key) }}
-                onMouseEnter={e => handleEnter(s.key, d, e)}
-                onMouseMove={e => handleMove(s.key, d, e)}
-                onMouseLeave={handleLeave}
-              />
-            ))}
-          </g>
-        ))}
-      </Chart>
-    </div>
-  )
-
-  const legend = showLegend !== false && legendItems.length > 0
-    ? <Legend items={legendItems} position={resolvedPosition} />
-    : null
-
   return (
-    <div ref={wrapperRef} style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column', position: 'relative' }}>
-      {isLeading && legend}
-      {chart}
-      {!isLeading && legend}
+    <ChartLayout wrapperRef={wrapperRef} legendItems={legendItems} showLegend={showLegend} legendPosition={legendPosition} tooltip={
       <Tooltip visible={tooltip.visible} x={tooltip.x} y={tooltip.y}>
         {tooltip.key && (
           <>
@@ -101,14 +70,38 @@ const StackedBarChart = ({
           </>
         )}
       </Tooltip>
-    </div>
+    }>
+      <div className="StackedBarChart" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
+        <Chart dimensions={dimensions} label={[xLabel, yLabel].filter(Boolean).join(' / ')}>
+          <Axis dimension="x" scale={xScale} formatTick={d => d} label={xLabel} />
+          <Axis dimension="y" scale={yScale} formatTick={formatYTick} label={yLabel} />
+          {series.map(s => (
+            <g key={s.key} className="StackedBar__series">
+              {s.map((d, i) => (
+                <rect
+                  key={`${s.key}-${i}`}
+                  className="StackedBar__segment"
+                  x={xScale(xAccessor(d.data))}
+                  y={yScale(d[1])}
+                  width={xScale.bandwidth()}
+                  height={Math.max(0, yScale(d[0]) - yScale(d[1]))}
+                  style={{ fill: colorScale(s.key) }}
+                  onMouseEnter={e => handleEnter(s.key, d, e)}
+                  onMouseMove={e => handleMove(s.key, d, e)}
+                  onMouseLeave={hideTooltip}
+                />
+              ))}
+            </g>
+          ))}
+        </Chart>
+      </div>
+    </ChartLayout>
   )
 }
 
 StackedBarChart.propTypes = {
   data: PropTypes.array,
   xAccessor: accessorPropsType,
-  /** Series keys to stack — each key must be a numeric property on each datum. Required. */
   keys: PropTypes.arrayOf(PropTypes.string).isRequired,
   colors: PropTypes.arrayOf(PropTypes.string),
   xLabel: PropTypes.string,
@@ -121,6 +114,7 @@ StackedBarChart.propTypes = {
 
 StackedBarChart.defaultProps = {
   xAccessor: d => d.x,
+  showLegend: true,
 }
 
 export default StackedBarChart

--- a/src/Charts/Timeline.js
+++ b/src/Charts/Timeline.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react"
+import React, { useCallback, useMemo, useState } from "react"
 import PropTypes from "prop-types"
 import * as d3 from "d3"
 
@@ -7,168 +7,156 @@ import Line from "../Components/Line"
 import Circles from "../Components/Circles"
 import Axis from "../Cartesian/Axis"
 import Gradient from "../Components/Gradient"
-import Legend from "../Components/Legend"
+import ChartLayout from "../Components/ChartLayout"
 import Tooltip from "../Components/Tooltip"
 import { useChartDimensions, accessorPropsType, useUniqueId } from "../Utils/utils"
+import { useTooltip } from "../Utils/useTooltip"
 
 const formatDate = d3.timeFormat("%-b %-d")
 const formatTooltipDate = d3.timeFormat("%-b %-d, %Y")
-const defaultGradientColors = ["rgb(226, 222, 243)", "#f8f9fa"]
+const DEFAULT_GRADIENT = ["rgb(226, 222, 243)", "#f8f9fa"]
 const DEFAULT_COLOR = '#9980FA'
 const fmt = d3.format(",")
 
 const Timeline = ({
   data, xAccessor, yAccessor, xLabel, yLabel,
-  color, gradientColors: gradientColorsProp,
+  color, gradientColors,
   interpolation, showArea, showDots,
   formatXTick, formatYTick,
   showLegend, legendPosition,
 }) => {
   const [ref, dimensions] = useChartDimensions({ marginBottom: 77 })
   const gradientId = useUniqueId("Timeline-gradient")
-  const wrapperRef = useRef()
-  const [hovered, setHovered] = useState(null)
-  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0 })
+  const { wrapperRef, tooltip, showTooltip, hideTooltip } = useTooltip()
+  const [hoveredIndex, setHoveredIndex] = useState(null)
 
-  if (!data || data.length === 0) return null
+  const resolvedGradientColors = gradientColors
+    || (color ? [`${color}55`, "rgba(255,255,255,0)"] : DEFAULT_GRADIENT)
 
-  const resolvedGradientColors = gradientColorsProp
-    || (color ? [`${color}55`, "rgba(255,255,255,0)"] : defaultGradientColors)
+  const xScale = useMemo(() =>
+    d3.scaleTime()
+      .domain(d3.extent(data, xAccessor))
+      .range([0, dimensions.boundedWidth]),
+    [data, xAccessor, dimensions.boundedWidth]
+  )
 
-  const xScale = d3.scaleTime()
-    .domain(d3.extent(data, xAccessor))
-    .range([0, dimensions.boundedWidth])
+  const yScale = useMemo(() =>
+    d3.scaleLinear()
+      .domain(d3.extent(data, yAccessor))
+      .range([dimensions.boundedHeight, 0])
+      .nice(),
+    [data, yAccessor, dimensions.boundedHeight]
+  )
 
-  const yScale = d3.scaleLinear()
-    .domain(d3.extent(data, yAccessor))
-    .range([dimensions.boundedHeight, 0])
-    .nice()
+  const legendItems = useMemo(() =>
+    yLabel ? [{ color: color || DEFAULT_COLOR, label: yLabel }] : [],
+    [yLabel, color]
+  )
 
-  const xAccessorScaled = d => xScale(xAccessor(d))
-  const yAccessorScaled = d => yScale(yAccessor(d))
-  const y0AccessorScaled = yScale(yScale.domain()[0])
+  const bisect = useMemo(() => d3.bisector(xAccessor).left, [xAccessor])
 
-  const bisect = d3.bisector(xAccessor).left
-
-  const handleMouseMove = e => {
+  const handleMouseMove = useCallback(e => {
     const svgEl = e.currentTarget.ownerSVGElement
-    const svgBounds = svgEl.getBoundingClientRect()
-    const mouseX = e.clientX - svgBounds.left - dimensions.marginLeft
-
+    const { left: svgLeft } = svgEl.getBoundingClientRect()
+    const mouseX = e.clientX - svgLeft - dimensions.marginLeft
     const date = xScale.invert(mouseX)
     const idx = bisect(data, date, 1)
     const d0 = data[idx - 1]
     const d1 = data[idx]
-    const hoveredDatum = !d1 || (d0 && date - xAccessor(d0) < xAccessor(d1) - date)
-      ? idx - 1 : idx
+    const i = !d1 || (d0 && date - xAccessor(d0) < xAccessor(d1) - date) ? idx - 1 : idx
+    setHoveredIndex(i)
+    showTooltip(e, { datum: data[i] })
+  }, [data, xAccessor, xScale, bisect, dimensions.marginLeft, showTooltip])
 
-    setHovered(hoveredDatum)
+  const handleMouseLeave = useCallback(() => {
+    setHoveredIndex(null)
+    hideTooltip()
+  }, [hideTooltip])
 
-    const { left, top } = wrapperRef.current.getBoundingClientRect()
-    setTooltip({ visible: true, x: e.clientX - left, y: e.clientY - top })
-  }
+  if (!data || data.length === 0) return null
 
-  const handleMouseLeave = () => {
-    setHovered(null)
-    setTooltip(t => ({ ...t, visible: false }))
-  }
-
-  const hoveredDatum = hovered !== null ? data[hovered] : null
+  const xAccessorScaled = d => xScale(xAccessor(d))
+  const yAccessorScaled = d => yScale(yAccessor(d))
+  const y0AccessorScaled = yScale(yScale.domain()[0])
+  const hoveredDatum = hoveredIndex !== null ? data[hoveredIndex] : null
   const yFmt = formatYTick || fmt
   const xFmt = formatXTick || formatTooltipDate
 
-  const legendItems = yLabel
-    ? [{ color: color || DEFAULT_COLOR, label: yLabel }]
-    : []
-  const resolvedPosition = legendPosition || 'bottom'
-  const isHorizontal = resolvedPosition === 'left' || resolvedPosition === 'right'
-  const isLeading = resolvedPosition === 'top' || resolvedPosition === 'left'
-
-  const chart = (
-    <div className="Timeline" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
-      <Chart dimensions={dimensions} label={yLabel || xLabel}>
-        <defs>
-          <Gradient id={gradientId} colors={resolvedGradientColors} x2="0" y2="100%" />
-        </defs>
-        <Axis dimension="x" scale={xScale} formatTick={formatXTick || formatDate} label={xLabel} />
-        <Axis dimension="y" scale={yScale} formatTick={formatYTick} label={yLabel} />
-        {showArea !== false && (
-          <Line
-            type="area"
-            data={data}
-            xAccessor={xAccessorScaled}
-            yAccessor={yAccessorScaled}
-            y0Accessor={y0AccessorScaled}
-            style={{ fill: `url(#${gradientId})` }}
-            interpolation={interpolation}
-          />
-        )}
-        <Line
-          data={data}
-          xAccessor={xAccessorScaled}
-          yAccessor={yAccessorScaled}
-          style={color ? { stroke: color } : undefined}
-          interpolation={interpolation}
-        />
-        {showDots && (
-          <Circles
-            data={data}
-            keyAccessor={(d, i) => i}
-            xAccessor={xAccessorScaled}
-            yAccessor={yAccessorScaled}
-            color={color}
-          />
-        )}
-        {hoveredDatum && (
-          <>
-            <line
-              className="Timeline__hover-line"
-              x1={xAccessorScaled(hoveredDatum)}
-              x2={xAccessorScaled(hoveredDatum)}
-              y1={0}
-              y2={dimensions.boundedHeight}
-            />
-            <circle
-              className="Timeline__hover-dot"
-              cx={xAccessorScaled(hoveredDatum)}
-              cy={yAccessorScaled(hoveredDatum)}
-              r={5}
-              style={{ stroke: color || DEFAULT_COLOR }}
-            />
-          </>
-        )}
-        <rect
-          x={0}
-          y={0}
-          width={dimensions.boundedWidth}
-          height={dimensions.boundedHeight}
-          fill="none"
-          style={{ pointerEvents: 'all' }}
-          onMouseMove={handleMouseMove}
-          onMouseLeave={handleMouseLeave}
-        />
-      </Chart>
-    </div>
-  )
-
-  const legend = showLegend && legendItems.length > 0
-    ? <Legend items={legendItems} position={resolvedPosition} />
-    : null
-
   return (
-    <div ref={wrapperRef} style={{ width: '100%', height: '100%', display: 'flex', flexDirection: isHorizontal ? 'row' : 'column', position: 'relative' }}>
-      {isLeading && legend}
-      {chart}
-      {!isLeading && legend}
+    <ChartLayout wrapperRef={wrapperRef} legendItems={legendItems} showLegend={showLegend} legendPosition={legendPosition} tooltip={
       <Tooltip visible={tooltip.visible} x={tooltip.x} y={tooltip.y}>
-        {hoveredDatum && (
+        {tooltip.datum && (
           <>
-            <div><strong>{xFmt(xAccessor(hoveredDatum))}</strong></div>
-            <div>{yLabel || 'Value'}: {yFmt(yAccessor(hoveredDatum))}</div>
+            <div><strong>{xFmt(xAccessor(tooltip.datum))}</strong></div>
+            <div>{yLabel || 'Value'}: {yFmt(yAccessor(tooltip.datum))}</div>
           </>
         )}
       </Tooltip>
-    </div>
+    }>
+      <div className="Timeline" ref={ref} style={{ flex: 1, minHeight: 0, minWidth: 0 }}>
+        <Chart dimensions={dimensions} label={yLabel || xLabel}>
+          <defs>
+            <Gradient id={gradientId} colors={resolvedGradientColors} x2="0" y2="100%" />
+          </defs>
+          <Axis dimension="x" scale={xScale} formatTick={formatXTick || formatDate} label={xLabel} />
+          <Axis dimension="y" scale={yScale} formatTick={formatYTick} label={yLabel} />
+          {showArea !== false && (
+            <Line
+              type="area"
+              data={data}
+              xAccessor={xAccessorScaled}
+              yAccessor={yAccessorScaled}
+              y0Accessor={y0AccessorScaled}
+              style={{ fill: `url(#${gradientId})` }}
+              interpolation={interpolation}
+            />
+          )}
+          <Line
+            data={data}
+            xAccessor={xAccessorScaled}
+            yAccessor={yAccessorScaled}
+            style={color ? { stroke: color } : undefined}
+            interpolation={interpolation}
+          />
+          {showDots && (
+            <Circles
+              data={data}
+              keyAccessor={(d, i) => i}
+              xAccessor={xAccessorScaled}
+              yAccessor={yAccessorScaled}
+              color={color}
+            />
+          )}
+          {hoveredDatum && (
+            <>
+              <line
+                className="Timeline__hover-line"
+                x1={xAccessorScaled(hoveredDatum)}
+                x2={xAccessorScaled(hoveredDatum)}
+                y1={0}
+                y2={dimensions.boundedHeight}
+              />
+              <circle
+                className="Timeline__hover-dot"
+                cx={xAccessorScaled(hoveredDatum)}
+                cy={yAccessorScaled(hoveredDatum)}
+                r={5}
+                style={{ stroke: color || DEFAULT_COLOR }}
+              />
+            </>
+          )}
+          <rect
+            x={0} y={0}
+            width={dimensions.boundedWidth}
+            height={dimensions.boundedHeight}
+            fill="none"
+            style={{ pointerEvents: 'all' }}
+            onMouseMove={handleMouseMove}
+            onMouseLeave={handleMouseLeave}
+          />
+        </Chart>
+      </div>
+    </ChartLayout>
   )
 }
 

--- a/src/Components/Bars.js
+++ b/src/Components/Bars.js
@@ -28,6 +28,9 @@ Bars.propTypes = {
   yAccessor: accessorPropsType,
   widthAccessor: accessorPropsType,
   heightAccessor: accessorPropsType,
+  onMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  onMouseMove: PropTypes.func,
 }
 
 Bars.defaultProps = {

--- a/src/Components/ChartLayout.js
+++ b/src/Components/ChartLayout.js
@@ -1,0 +1,39 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Legend from './Legend'
+
+const COL_STYLE = { width: '100%', height: '100%', display: 'flex', flexDirection: 'column', position: 'relative' }
+const ROW_STYLE = { width: '100%', height: '100%', display: 'flex', flexDirection: 'row', position: 'relative' }
+
+const ChartLayout = ({ wrapperRef, legendItems, showLegend, legendPosition, tooltip, children }) => {
+  const position = legendPosition || 'bottom'
+  const isHorizontal = position === 'left' || position === 'right'
+  const isLeading = position === 'top' || position === 'left'
+
+  const legend = showLegend && legendItems && legendItems.length > 0
+    ? <Legend items={legendItems} position={position} />
+    : null
+
+  return (
+    <div ref={wrapperRef} style={isHorizontal ? ROW_STYLE : COL_STYLE}>
+      {isLeading && legend}
+      {children}
+      {!isLeading && legend}
+      {tooltip}
+    </div>
+  )
+}
+
+ChartLayout.propTypes = {
+  wrapperRef: PropTypes.object,
+  legendItems: PropTypes.arrayOf(PropTypes.shape({
+    color: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+  })),
+  showLegend: PropTypes.bool,
+  legendPosition: PropTypes.oneOf(['top', 'bottom', 'left', 'right']),
+  tooltip: PropTypes.node,
+  children: PropTypes.node,
+}
+
+export default ChartLayout

--- a/src/Components/Circles.js
+++ b/src/Components/Circles.js
@@ -26,8 +26,10 @@ Circles.propTypes = {
   xAccessor: accessorPropsType,
   yAccessor: accessorPropsType,
   radius: accessorPropsType,
-  /** Fill color for each circle. */
   color: PropTypes.string,
+  onMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
+  onMouseMove: PropTypes.func,
 }
 
 Circles.defaultProps = {

--- a/src/Components/index.js
+++ b/src/Components/index.js
@@ -1,5 +1,8 @@
 export { default as Bars } from "./Bars";
 export { default as Chart } from "./Chart";
+export { default as ChartLayout } from "./ChartLayout";
 export { default as Circles } from "./Circles";
-export { default as Line } from "./Line";
 export { default as Gradient } from "./Gradient";
+export { default as Legend } from "./Legend";
+export { default as Line } from "./Line";
+export { default as Tooltip } from "./Tooltip";

--- a/src/Utils/useTooltip.js
+++ b/src/Utils/useTooltip.js
@@ -1,0 +1,22 @@
+import { useRef, useState, useCallback } from 'react'
+
+export function useTooltip() {
+  const wrapperRef = useRef()
+  const [tooltip, setTooltip] = useState({ visible: false, x: 0, y: 0 })
+
+  const showTooltip = useCallback((e, data) => {
+    const { left, top } = wrapperRef.current.getBoundingClientRect()
+    setTooltip({ visible: true, x: e.clientX - left, y: e.clientY - top, ...data })
+  }, [])
+
+  const moveTooltip = useCallback(e => {
+    const { left, top } = wrapperRef.current.getBoundingClientRect()
+    setTooltip(t => ({ ...t, x: e.clientX - left, y: e.clientY - top }))
+  }, [])
+
+  const hideTooltip = useCallback(() => {
+    setTooltip(t => ({ ...t, visible: false }))
+  }, [])
+
+  return { wrapperRef, tooltip, showTooltip, moveTooltip, hideTooltip }
+}


### PR DESCRIPTION
- useTooltip hook: consolidates wrapperRef, tooltip state, and showTooltip/moveTooltip/hideTooltip handlers shared across all charts
- ChartLayout component: consolidates the legend+wrapper+tooltip layout pattern duplicated in every chart
- useMemo for all D3 scale and bin computations so tooltip hover re-renders do not recompute scales unnecessarily
- useCallback for all event handlers for stable references
- useMemo for legendItems, barStyle, colorScale
- Bars/Circles: add onMouseEnter/Leave/Move to propTypes
- ChartLayout/Legend/Tooltip exported from Components/index.js
- StackedBarChart: fix segment keys from index-only to key+index, add showLegend defaultProp true
